### PR TITLE
fix: make EPSS import idempotent

### DIFF
--- a/backend/application/epss/services/epss.py
+++ b/backend/application/epss/services/epss.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import requests
 from django.core.paginator import Paginator
+from django.db import connection
 
 from application.core.models import Observation
 from application.core.types import Status
@@ -19,11 +20,7 @@ def import_epss() -> str:
     response.raise_for_status()
     extracted_data = gzip.decompress(response.content)
 
-    EPSS_Score.objects.all().delete()
-
-    counter = 0
-    scores = []
-    num_epss_scores = 0
+    scores_by_cve: dict[str, EPSS_Score] = {}
     for line in extracted_data.split(b"\n"):
         decoded_line = line.decode()
 
@@ -37,23 +34,67 @@ def import_epss() -> str:
         if decoded_line.startswith("CVE"):
             elements = decoded_line.split(",")
             if len(elements) == 3:
-                scores.append(
-                    EPSS_Score(
-                        cve=elements[0],
-                        epss_score=elements[1],
-                        epss_percentile=elements[2],
-                    )
+                scores_by_cve[elements[0]] = EPSS_Score(
+                    cve=elements[0],
+                    epss_score=elements[1],
+                    epss_percentile=elements[2],
                 )
-                num_epss_scores += 1
-                counter += 1
-            if counter == 1000:
-                EPSS_Score.objects.bulk_create(scores)
-                counter = 0
-                scores = []
-    if scores:
-        EPSS_Score.objects.bulk_create(scores)
 
-    return f"Imported {num_epss_scores} EPSS scores."
+    _upsert_epss_scores(list(scores_by_cve.values()))
+
+    return f"Imported {len(scores_by_cve)} EPSS scores."
+
+
+def _upsert_epss_scores(scores: list[EPSS_Score]) -> None:
+    if not scores:
+        return
+
+    update_fields = ["epss_score", "epss_percentile"]
+    if connection.features.supports_update_conflicts_with_target:
+        EPSS_Score.objects.bulk_create(
+            scores,
+            batch_size=1000,
+            update_conflicts=True,
+            update_fields=update_fields,
+            unique_fields=["cve"],
+        )
+        return
+
+    if connection.features.supports_update_conflicts:
+        EPSS_Score.objects.bulk_create(
+            scores,
+            batch_size=1000,
+            update_conflicts=True,
+            update_fields=update_fields,
+        )
+        return
+
+    _bulk_update_or_create_epss_scores(scores, update_fields)
+
+
+def _bulk_update_or_create_epss_scores(scores: list[EPSS_Score], update_fields: list[str]) -> None:
+    for score_batch in _chunks(scores, 1000):
+        cves = [score.cve for score in score_batch]
+        existing_scores = {score.cve: score for score in EPSS_Score.objects.filter(cve__in=cves)}
+        scores_to_update = []
+        scores_to_create = []
+
+        for score in score_batch:
+            if existing_score := existing_scores.get(score.cve):
+                existing_score.epss_score = score.epss_score
+                existing_score.epss_percentile = score.epss_percentile
+                scores_to_update.append(existing_score)
+            else:
+                scores_to_create.append(score)
+
+        if scores_to_update:
+            EPSS_Score.objects.bulk_update(scores_to_update, update_fields)
+        if scores_to_create:
+            EPSS_Score.objects.bulk_create(scores_to_create, ignore_conflicts=True)
+
+
+def _chunks(scores: list[EPSS_Score], chunk_size: int) -> list[list[EPSS_Score]]:
+    return [scores[index : index + chunk_size] for index in range(0, len(scores), chunk_size)]
 
 
 def epss_apply_observations() -> str:

--- a/backend/unittests/epss/services/test_epss.py
+++ b/backend/unittests/epss/services/test_epss.py
@@ -1,20 +1,65 @@
-from unittest.mock import call, patch
+import gzip
+from decimal import Decimal
+from unittest.mock import Mock, call, patch
 
 from django.core.management import call_command
 
 from application.core.models import Observation
-from application.epss.models import EPSS_Score
+from application.epss.models import EPSS_Score, EPSS_Status
 from application.epss.services.epss import (
     apply_epss,
     epss_apply_observations,
+    import_epss,
 )
 from unittests.base_test_case import BaseTestCase
 
 
 class TestEPSS(BaseTestCase):
+    @patch("application.epss.services.epss.requests.get")
+    def test_import_epss_updates_existing_score(self, mock_get):
+        EPSS_Score.objects.create(cve="CVE-2025-5642", epss_score=0.10000, epss_percentile=0.20000)
+        mock_get.return_value = self._mock_epss_response(
+            b"#model_version:v2024.03.14,score_date:2026-05-18\n"
+            b"cve,epss,percentile\n"
+            b"CVE-2025-5642,0.30000,0.40000\n"
+        )
+
+        message = import_epss()
+
+        score = EPSS_Score.objects.get(cve="CVE-2025-5642")
+        self.assertEqual(score.epss_score, Decimal("0.30000"))
+        self.assertEqual(score.epss_percentile, Decimal("0.40000"))
+        self.assertEqual(EPSS_Score.objects.count(), 1)
+        self.assertEqual(message, "Imported 1 EPSS scores.")
+
+    @patch("application.epss.services.epss.requests.get")
+    def test_import_epss_deduplicates_feed_and_keeps_last_score(self, mock_get):
+        mock_get.return_value = self._mock_epss_response(
+            b"#model_version:v2024.03.14,score_date:2026-05-18\n"
+            b"cve,epss,percentile\n"
+            b"CVE-2025-5642,0.10000,0.20000\n"
+            b"CVE-2025-5642,0.30000,0.40000\n"
+        )
+
+        message = import_epss()
+
+        score = EPSS_Score.objects.get(cve="CVE-2025-5642")
+        self.assertEqual(score.epss_score, Decimal("0.30000"))
+        self.assertEqual(score.epss_percentile, Decimal("0.40000"))
+        self.assertEqual(EPSS_Score.objects.count(), 1)
+        self.assertEqual(EPSS_Status.load().score_date.isoformat(), "2026-05-18")
+        self.assertEqual(message, "Imported 1 EPSS scores.")
+
+    @staticmethod
+    def _mock_epss_response(content: bytes) -> Mock:
+        response = Mock()
+        response.content = gzip.compress(content)
+        response.raise_for_status.return_value = None
+        return response
+
     @classmethod
     @patch("application.core.signals.get_current_user")
-    def setUpClass(self, mock_user):
+    def setUpClass(cls, mock_user):
         mock_user.return_value = None
         call_command("loaddata", "unittests/fixtures/unittests_fixtures.json")
         super().setUpClass()


### PR DESCRIPTION
## Summary
- Replace delete-then-bulk-create EPSS import with backend-supported bulk upsert on the unique CVE key.
- Deduplicate duplicate CVE rows from the EPSS feed deterministically, keeping the last score seen in the feed.
- Add regression coverage for duplicate feed rows and updating an existing CVE score.

## Root cause
The EPSS importer deleted all EPSS rows and then inserted every CVE from the feed with plain bulk_create(). If the feed contained a duplicate CVE in one import, or another task inserted the same CVE between delete and insert, the unique cve constraint raised IntegrityError and aborted task_import_epss.

## Test plan
- docker compose -f docker-compose-unittests.yml run --rm --build --entrypoint sh django -c 'python manage.py migrate >/tmp/migrate.log && python manage.py test unittests.epss.services.test_epss -v 2'
- docker compose -f docker-compose-unittests.yml run --rm --build django

## Data cleanup
No production data cleanup is required for the reported duplicate-key failure; the next EPSS import upserts the CVE row and updates existing rows in place.