### PR TITLE
Feat: Support Microsoft Teams Workflows (Power Automate) webhooks

### DIFF
--- a/backend/application/core/services/security_gate.py
+++ b/backend/application/core/services/security_gate.py
@@ -15,7 +15,9 @@ def check_security_gate(product: Product) -> None:
     settings = Settings.load()
 
     initial_security_gate_passed = product.security_gate_passed
-    new_security_gate_passed = None
+    new_security_gate_passed: Optional[bool] = None
+    annotated_product = product
+    thresholds: Optional[dict[str, int]] = None
 
     security_gate_active: Optional[bool]
     if product.product_group and product.product_group.security_gate_active is not None:
@@ -26,14 +28,16 @@ def check_security_gate(product: Product) -> None:
     if security_gate_active is False:
         new_security_gate_passed = None
     elif security_gate_active is True:
-        new_security_gate_passed = _calculate_active_product_security_gate(product)
+        new_security_gate_passed, annotated_product, thresholds = _calculate_active_product_security_gate(product)
     elif settings.security_gate_active:
-        new_security_gate_passed = _calculate_active_config_security_gate(product)
+        new_security_gate_passed, annotated_product, thresholds = _calculate_active_config_security_gate(product)
 
     if initial_security_gate_passed != new_security_gate_passed:
         product.security_gate_passed = new_security_gate_passed
         product.save()
-        send_product_security_gate_notification(product)
+        # Pass the annotated product (active observation counts) and the thresholds
+        # that were applied, so the notification can show the statistics.
+        send_product_security_gate_notification(annotated_product, thresholds)
 
 
 def check_security_gate_observation(observation: Observation) -> None:
@@ -41,7 +45,7 @@ def check_security_gate_observation(observation: Observation) -> None:
         check_security_gate(observation.product)
 
 
-def _calculate_active_product_security_gate(product: Product) -> bool:
+def _calculate_active_product_security_gate(product: Product) -> tuple[bool, Product, dict[str, int]]:
     new_security_gate_passed = True
 
     if product.product_group and product.product_group.security_gate_active is True:
@@ -119,10 +123,18 @@ def _calculate_active_product_security_gate(product: Product) -> bool:
     ):
         new_security_gate_passed = False
 
-    return new_security_gate_passed
+    thresholds = {
+        "critical": security_gate_threshold_critical,
+        "high": security_gate_threshold_high,
+        "medium": security_gate_threshold_medium,
+        "low": security_gate_threshold_low,
+        "none": security_gate_threshold_none,
+        "unknown": security_gate_threshold_unknown,
+    }
+    return new_security_gate_passed, annotated_product, thresholds
 
 
-def _calculate_active_config_security_gate(product: Product) -> bool:
+def _calculate_active_config_security_gate(product: Product) -> tuple[bool, Product, dict[str, int]]:
     settings = Settings.load()
 
     annotated_product = get_product_by_id(
@@ -152,4 +164,12 @@ def _calculate_active_config_security_gate(product: Product) -> bool:
     ):
         new_security_gate_passed = False
 
-    return new_security_gate_passed
+    thresholds = {
+        "critical": settings.security_gate_threshold_critical,
+        "high": settings.security_gate_threshold_high,
+        "medium": settings.security_gate_threshold_medium,
+        "low": settings.security_gate_threshold_low,
+        "none": settings.security_gate_threshold_none,
+        "unknown": settings.security_gate_threshold_unknown,
+    }
+    return new_security_gate_passed, annotated_product, thresholds

--- a/backend/application/notifications/services/send_notifications.py
+++ b/backend/application/notifications/services/send_notifications.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("secobserve.notifications")
 LAST_EXCEPTIONS: dict[str, datetime] = {}
 
 
-def send_product_security_gate_notification(product: Product) -> None:
+def send_product_security_gate_notification(product: Product, thresholds: Optional[dict[str, int]] = None) -> None:
     settings = Settings.load()
 
     if product.security_gate_passed is None:
@@ -49,12 +49,27 @@ def send_product_security_gate_notification(product: Product) -> None:
 
     notification_ms_teams_webhook = _get_notification_ms_teams_webhook(product)
     if notification_ms_teams_webhook:
+        severity_stats = [
+            {
+                "label": label,
+                "count": getattr(product, f"active_{key}_observation_count", None),
+                "threshold": thresholds.get(key) if thresholds else None,
+            }
+            for label, key in (
+                ("Critical", "critical"),
+                ("High", "high"),
+                ("Medium", "medium"),
+                ("Low", "low"),
+                ("Unknown", "unknown"),
+            )
+        ]
         send_msteams_notification(
             notification_ms_teams_webhook,
             "msteams_product_security_gate.tpl",
             product=product,
             security_gate_status=security_gate_status,
             product_url=f"{get_base_url_frontend()}#/products/{product.id}/show",
+            severity_stats=severity_stats,
         )
 
     notification_slack_webhook = _get_notification_slack_webhook(product)

--- a/backend/application/notifications/services/send_notifications_base.py
+++ b/backend/application/notifications/services/send_notifications_base.py
@@ -15,6 +15,17 @@ from application.commons.services.log_message import format_log_message
 
 logger = logging.getLogger("secobserve.notifications")
 
+# Host suffixes for Microsoft Teams "Workflows" (Power Automate) webhook trigger
+# URLs, used only as a fallback to the "/workflows/" path check below:
+#   current: <env>.environment.api.powerplatform.com
+#   legacy:  prod-NN.<region>.logic.azure.com   (HTTP-trigger URLs, retired 2025-11-30)
+# Legacy Office 365 "Incoming Webhook" connectors are on *.webhook.office.com and
+# take a MessageCard instead; they are detected by the absence of these signals.
+_MSTEAMS_WORKFLOW_HOST_SUFFIXES = (
+    ".environment.api.powerplatform.com",
+    ".logic.azure.com",
+)
+
 
 @db_task()
 def send_email_notification(notification_email_to: str, subject: str, template: str, **kwargs: Any) -> None:
@@ -43,16 +54,28 @@ def send_email_notification(notification_email_to: str, subject: str, template: 
 def send_msteams_notification(webhook: str, template: str, **kwargs: Any) -> None:
     if not _validate_webhook_url(webhook):
         return
+
+    # Workflows webhooks need an Adaptive Card; legacy connectors keep the
+    # MessageCard template the caller passed in.
+    is_workflow = _is_msteams_workflow_webhook(webhook)
+    if is_workflow:
+        template = _get_msteams_workflow_template(template)
+
     notification_message = _create_notification_message(template, **kwargs)
     if notification_message:
         try:
-            response = requests.request(
-                method="POST",
-                url=webhook,
-                data=notification_message,
-                allow_redirects=False,
-                timeout=60,
-            )
+            request_kwargs: dict[str, Any] = {
+                "method": "POST",
+                "url": webhook,
+                "data": notification_message,
+                "allow_redirects": False,
+                "timeout": 60,
+            }
+            if is_workflow:
+                # Power Automate only parses the body as JSON when told to; the
+                # legacy connector accepts it without an explicit content type.
+                request_kwargs["headers"] = {"Content-Type": "application/json"}
+            response = requests.request(**request_kwargs)
             response.raise_for_status()
         except Exception as e:
             logger.error(
@@ -126,6 +149,27 @@ def _validate_webhook_url(webhook: str) -> bool:
             return False
 
     return True
+
+
+def _is_msteams_workflow_webhook(webhook: str) -> bool:
+    split_url = urlsplit(webhook)
+    # Primary, format-stable signal: both the current and legacy trigger URLs
+    # carry ".../workflows/<id>/triggers/manual/paths/invoke" in their path.
+    # Checking split_url.path (not the raw URL) keeps the query string out of it.
+    if "/workflows/" in split_url.path.lower():
+        return True
+    # Host fallback in case Microsoft changes the path. urlsplit().hostname is
+    # already lower-cased and port-stripped (so an explicit :443 is ignored).
+    hostname = (split_url.hostname or "").lower()
+    return hostname.endswith(_MSTEAMS_WORKFLOW_HOST_SUFFIXES)
+
+
+def _get_msteams_workflow_template(template: str) -> str:
+    # Map a MessageCard template to its Adaptive Card sibling, e.g.
+    # "msteams_observation.tpl" -> "msteams_observation_workflow.tpl".
+    if template.endswith(".tpl"):
+        return f"{template[:-len('.tpl')]}_workflow.tpl"
+    return f"{template}_workflow"
 
 
 def _create_notification_message(template: str, **kwargs: Any) -> Optional[str]:

--- a/backend/application/notifications/templates/msteams_exception_workflow.tpl
+++ b/backend/application/notifications/templates/msteams_exception_workflow.tpl
@@ -1,0 +1,44 @@
+{# MS Teams Workflows (Power Automate) payload — Adaptive Card. MessageCard sibling: msteams_exception.tpl #}
+{
+    "type": "message",
+    "attachments": [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "text": "Exception {{ exception_class|escapejs }} has occured",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "wrap": true
+                    },
+                    {
+                        "type": "FactSet",
+                        "facts": [
+                            {
+                                "title": "Exception class:",
+                                "value": "{{ exception_class|escapejs }}"
+                            },
+                            {
+                                "title": "Exception message:",
+                                "value": "{{ exception_message|escapejs }}"
+                            },
+                            {
+                                "title": "Timestamp:",
+                                "value": "{{ date_time|date:"Y-m-d H:i:s.u"|escapejs }}"
+                            },
+                            {
+                                "title": "Trace:",
+                                "value": "{{ exception_trace|escapejs }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/backend/application/notifications/templates/msteams_observation_title_workflow.tpl
+++ b/backend/application/notifications/templates/msteams_observation_title_workflow.tpl
@@ -1,0 +1,47 @@
+{# MS Teams Workflows (Power Automate) payload — Adaptive Card. MessageCard sibling: msteams_observation_title.tpl #}
+{
+    "type": "message",
+    "attachments": [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "text": "{{ first_line|escapejs }}",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "wrap": true
+                    },
+                    {
+                        "type": "FactSet",
+                        "facts": [
+                            {
+                                "title": "Severity:",
+                                "value": "{{ observation.current_severity|escapejs }}"
+                            },
+                            {
+                                "title": "Status:",
+                                "value": "{{ observation.current_status|escapejs }}"
+                            },
+                            {
+                                "title": "Priority:",
+                                "value": "{{ observation.current_priority|escapejs }}"
+                            }
+                        ]
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.OpenUrl",
+                        "title": "View observation title {{ observation.title|escapejs }}",
+                        "url": "{{ url|escapejs }}"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/backend/application/notifications/templates/msteams_observation_workflow.tpl
+++ b/backend/application/notifications/templates/msteams_observation_workflow.tpl
@@ -1,0 +1,51 @@
+{# MS Teams Workflows (Power Automate) payload — Adaptive Card. MessageCard sibling: msteams_observation.tpl #}
+{
+    "type": "message",
+    "attachments": [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "text": "{{ first_line|escapejs }}",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "wrap": true
+                    },
+                    {
+                        "type": "FactSet",
+                        "facts": [
+                            {
+                                "title": "Product:",
+                                "value": "{{ observation.product.name|escapejs }}"
+                            },
+                            {
+                                "title": "Severity:",
+                                "value": "{{ observation.current_severity|escapejs }}"
+                            },
+                            {
+                                "title": "Status:",
+                                "value": "{{ observation.current_status|escapejs }}"
+                            },
+                            {
+                                "title": "Priority:",
+                                "value": "{{ observation.current_priority|escapejs }}"
+                            }
+                        ]
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.OpenUrl",
+                        "title": "View observation {{ observation.title|escapejs }}",
+                        "url": "{{ observation_url|escapejs }}"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/backend/application/notifications/templates/msteams_product_security_gate_workflow.tpl
+++ b/backend/application/notifications/templates/msteams_product_security_gate_workflow.tpl
@@ -1,0 +1,53 @@
+{# MS Teams Workflows (Power Automate) payload — Adaptive Card. MessageCard sibling: msteams_product_security_gate.tpl #}
+{
+    "type": "message",
+    "attachments": [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": [
+                    {
+                        "type": "Container",
+                        "bleed": true,
+                        "style": "{% if security_gate_status == 'Failed' %}attention{% elif security_gate_status == 'Passed' %}good{% else %}default{% endif %}",
+                        "items": [
+                            {
+                                "type": "TextBlock",
+                                "text": "{% if security_gate_status == 'Failed' %}🔴 Security gate failed{% elif security_gate_status == 'Passed' %}🟢 Security gate passed{% else %}⚪ Security gate disabled{% endif %}",
+                                "weight": "Bolder",
+                                "size": "Large",
+                                "wrap": true
+                            },
+                            {
+                                "type": "TextBlock",
+                                "text": "{{ product.name|escapejs }}",
+                                "spacing": "None",
+                                "isSubtle": true,
+                                "wrap": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "FactSet",
+                        "facts": [{% for stat in severity_stats %}{% if not forloop.first %},{% endif %}
+                            {
+                                "title": "{{ stat.label|escapejs }}",
+                                "value": "{% if stat.count is not None %}{{ stat.count }}{% else %}n/a{% endif %}{% if stat.threshold is not None %} / allowed {{ stat.threshold }}{% endif %}"
+                            }{% endfor %}
+                        ]
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.OpenUrl",
+                        "title": "View product {{ product.name|escapejs }}",
+                        "url": "{{ product_url|escapejs }}"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/backend/application/notifications/templates/msteams_task_exception_workflow.tpl
+++ b/backend/application/notifications/templates/msteams_task_exception_workflow.tpl
@@ -1,0 +1,56 @@
+{# MS Teams Workflows (Power Automate) payload — Adaptive Card. MessageCard sibling: msteams_task_exception.tpl #}
+{
+    "type": "message",
+    "attachments": [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "text": "Exception {{ exception_class|escapejs }} has occured while processing background task",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "wrap": true
+                    },
+                    {
+                        "type": "FactSet",
+                        "facts": [
+                            {
+                                "title": "Function:",
+                                "value": "{{ function|escapejs }}"
+                            },
+                            {
+                                "title": "Arguments:",
+                                "value": "{{ arguments|escapejs }}"
+                            },
+                            {
+                                "title": "User:",
+                                "value": "{{ user.full_name|escapejs }}"
+                            },
+                            {
+                                "title": "Exception class:",
+                                "value": "{{ exception_class|escapejs }}"
+                            },
+                            {
+                                "title": "Exception message:",
+                                "value": "{{ exception_message|escapejs }}"
+                            },
+                            {
+                                "title": "Timestamp:",
+                                "value": "{{ date_time|date:"Y-m-d H:i:s.u"|escapejs }}"
+                            },
+                            {
+                                "title": "Trace:",
+                                "value": "{{ exception_trace|escapejs }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/backend/unittests/core/services/test_security_gate.py
+++ b/backend/unittests/core/services/test_security_gate.py
@@ -30,7 +30,8 @@ class TestSecurityGate(BaseTestCase):
 
         self.assertIsNone(product.security_gate_passed)
         save_mock.assert_called()
-        notification_mock.assert_called_with(product)
+        # Gate disabled -> no thresholds resolved, so they are passed as None.
+        notification_mock.assert_called_with(product, None)
 
     @patch("application.core.models.Product.save")
     @patch("application.core.services.security_gate.send_product_security_gate_notification")
@@ -46,7 +47,7 @@ class TestSecurityGate(BaseTestCase):
 
         self.assertIsNone(product.security_gate_passed)
         save_mock.assert_called()
-        notification_mock.assert_called_with(product)
+        notification_mock.assert_called_with(product, None)
 
     @patch("application.core.services.security_gate.get_product_by_id")
     def test_check_security_gate_true_critical(self, get_product_mock):

--- a/backend/unittests/notifications/services/test_send_notifications.py
+++ b/backend/unittests/notifications/services/test_send_notifications.py
@@ -130,6 +130,7 @@ class TestPushNotifications(BaseTestCase):
             product=self.product_1,
             security_gate_status="None",
             product_url="https://secobserve.com/#/products/1/show",
+            severity_stats=ANY,
         )
         mock_send_slack.assert_called_with(
             "https://secobserve.slack.com",
@@ -219,6 +220,7 @@ class TestPushNotifications(BaseTestCase):
             product=self.product_1,
             security_gate_status="Passed",
             product_url="https://secobserve.com/#/products/1/show",
+            severity_stats=ANY,
         )
         mock_send_slack.assert_called_with(
             "https://secobserve.slack.com",
@@ -308,6 +310,7 @@ class TestPushNotifications(BaseTestCase):
             product=self.product_1,
             security_gate_status="Failed",
             product_url="https://secobserve.com/#/products/1/show",
+            severity_stats=ANY,
         )
         mock_send_slack.assert_called_with(
             "https://secobserve.slack.com",

--- a/backend/unittests/notifications/services/test_send_notifications_base.py
+++ b/backend/unittests/notifications/services/test_send_notifications_base.py
@@ -1,19 +1,32 @@
 import json
 import os
+import unittest
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import requests
 from requests import Response
 
 from application.commons.models import Settings
 from application.commons.services.functions import get_classname
 from application.notifications.services.send_notifications_base import (
     _create_notification_message,
+    _get_msteams_workflow_template,
+    _is_msteams_workflow_webhook,
     send_email_notification,
     send_msteams_notification,
     send_slack_notification,
 )
 from unittests.base_test_case import BaseTestCase
+
+# Fictional Power Automate "Workflows" webhook URL (host suffix + /workflows/
+# path + explicit :443 port) used only to exercise the detection logic.
+WORKFLOW_WEBHOOK = (
+    "https://example.environment.api.powerplatform.com:443"
+    "/powerautomate/automations/direct/workflows/00000000000000000000000000000000"
+    "/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=test-signature"
+)
 
 
 class TestPushNotifications(BaseTestCase):
@@ -203,6 +216,88 @@ class TestPushNotifications(BaseTestCase):
         mock_logger.assert_not_called()
         mock_format.assert_not_called()
 
+    @patch("application.notifications.services.send_notifications_base._create_notification_message")
+    @patch("application.notifications.services.send_notifications_base.requests.request")
+    @patch("application.notifications.services.send_notifications_base.logger.error")
+    @patch("application.notifications.services.send_notifications_base.format_log_message")
+    @patch("application.notifications.services.send_notifications_base.socket.getaddrinfo")
+    def test_send_msteams_notification_workflow_webhook(
+        self, mock_getaddrinfo, mock_format, mock_logger, mock_request, mock_create_message
+    ):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("1.2.3.4", 443))]
+        mock_create_message.return_value = "test_message"
+        response = Response()
+        response.status_code = 200
+        mock_request.return_value = response
+
+        send_msteams_notification(WORKFLOW_WEBHOOK, "msteams_observation.tpl")
+
+        # The Adaptive Card variant is rendered instead of the MessageCard one ...
+        mock_create_message.assert_called_with("msteams_observation_workflow.tpl")
+        # ... and the request carries the JSON content type Power Automate needs.
+        mock_request.assert_called_with(
+            method="POST",
+            url=WORKFLOW_WEBHOOK,
+            data="test_message",
+            allow_redirects=False,
+            timeout=60,
+            headers={"Content-Type": "application/json"},
+        )
+        mock_logger.assert_not_called()
+        mock_format.assert_not_called()
+
+    @patch("application.notifications.services.send_notifications_base._create_notification_message")
+    @patch("application.notifications.services.send_notifications_base.requests.request")
+    @patch("application.notifications.services.send_notifications_base.socket.getaddrinfo")
+    def test_send_msteams_notification_connector_webhook_unchanged(
+        self, mock_getaddrinfo, mock_request, mock_create_message
+    ):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("1.2.3.4", 443))]
+        mock_create_message.return_value = "test_message"
+        response = Response()
+        response.status_code = 200
+        mock_request.return_value = response
+
+        send_msteams_notification("https://example.webhook.office.com/webhookb2/abc", "msteams_observation.tpl")
+
+        # Legacy connector keeps the MessageCard template and sends no extra header.
+        mock_create_message.assert_called_with("msteams_observation.tpl")
+        mock_request.assert_called_with(
+            method="POST",
+            url="https://example.webhook.office.com/webhookb2/abc",
+            data="test_message",
+            allow_redirects=False,
+            timeout=60,
+        )
+
+    # --- _is_msteams_workflow_webhook / _get_msteams_workflow_template ---
+
+    def test_is_msteams_workflow_webhook_true_by_path(self):
+        # The "/workflows/" path is present in both the current and legacy URL forms.
+        self.assertTrue(_is_msteams_workflow_webhook(WORKFLOW_WEBHOOK))
+        self.assertTrue(
+            _is_msteams_workflow_webhook(
+                "https://prod-12.westeurope.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke"
+            )
+        )
+        self.assertTrue(_is_msteams_workflow_webhook("https://example.org/foo/workflows/bar"))
+
+    def test_is_msteams_workflow_webhook_true_by_host(self):
+        # Host-suffix fallback (documented trigger hosts) even without the workflow path.
+        self.assertTrue(_is_msteams_workflow_webhook("https://env.environment.api.powerplatform.com/anything"))
+        self.assertTrue(_is_msteams_workflow_webhook("https://prod-00.eastus.logic.azure.com/health"))
+
+    def test_is_msteams_workflow_webhook_false(self):
+        self.assertFalse(_is_msteams_workflow_webhook("https://contoso.webhook.office.com/webhookb2/abc"))
+        self.assertFalse(_is_msteams_workflow_webhook("https://hooks.example.org/webhook"))
+        # azure-apim.net is the APIM OAuth-consent domain, not a webhook trigger host.
+        self.assertFalse(_is_msteams_workflow_webhook("https://global.consent.azure-apim.net/redirect/apim/x"))
+        self.assertFalse(_is_msteams_workflow_webhook(""))
+
+    def test_get_msteams_workflow_template(self):
+        self.assertEqual("msteams_observation_workflow.tpl", _get_msteams_workflow_template("msteams_observation.tpl"))
+        self.assertEqual("test_template_workflow", _get_msteams_workflow_template("test_template"))
+
     # --- send_slack_notification ---
 
     @patch("application.notifications.services.send_notifications_base._create_notification_message")
@@ -387,3 +482,135 @@ class TestPushNotifications(BaseTestCase):
             "extra",
             [action["name"] for action in parsed["potentialAction"]][0].split("View observation ")[-1][:4],
         )
+
+    # --- Adaptive Card (Workflows) templates ---
+
+    def _assert_adaptive_card_envelope(self, message):
+        parsed = json.loads(message)
+        self.assertEqual("message", parsed["type"])
+        attachment = parsed["attachments"][0]
+        self.assertEqual("application/vnd.microsoft.card.adaptive", attachment["contentType"])
+        self.assertEqual("AdaptiveCard", attachment["content"]["type"])
+        return parsed
+
+    def test_create_notification_message_security_gate_workflow(self):
+        message = _create_notification_message(
+            "msteams_product_security_gate_workflow.tpl",
+            product=self.product_1,
+            security_gate_status="Failed",
+            product_url="product_url",
+            severity_stats=[
+                {"label": "Critical", "count": 3, "threshold": 0},
+                {"label": "High", "count": 1, "threshold": 2},
+                {"label": "Medium", "count": 5, "threshold": 10},
+                {"label": "Low", "count": 0, "threshold": 0},
+                {"label": "Unknown", "count": 0, "threshold": 0},
+            ],
+        )
+
+        content = self._assert_adaptive_card_envelope(message)["attachments"][0]["content"]
+        header = content["body"][0]
+        self.assertEqual("attention", header["style"])
+        self.assertIn("failed", header["items"][0]["text"].lower())
+        facts = {fact["title"]: fact["value"] for fact in content["body"][1]["facts"]}
+        self.assertEqual(["Critical", "High", "Medium", "Low", "Unknown"], list(facts.keys()))
+        self.assertEqual("3 / allowed 0", facts["Critical"])
+        self.assertEqual("1 / allowed 2", facts["High"])
+        self.assertEqual("5 / allowed 10", facts["Medium"])
+        self.assertEqual("0 / allowed 0", facts["Unknown"])
+        self.assertEqual("product_url", content["actions"][0]["url"])
+
+    def test_create_notification_message_security_gate_workflow_disabled(self):
+        # No counts/thresholds (gate disabled) -> "n/a" and no "allowed" suffix.
+        message = _create_notification_message(
+            "msteams_product_security_gate_workflow.tpl",
+            product=self.product_1,
+            security_gate_status="None",
+            product_url="product_url",
+            severity_stats=[
+                {"label": "Critical", "count": None, "threshold": None},
+                {"label": "High", "count": None, "threshold": None},
+                {"label": "Medium", "count": None, "threshold": None},
+                {"label": "Low", "count": None, "threshold": None},
+                {"label": "Unknown", "count": None, "threshold": None},
+            ],
+        )
+
+        content = self._assert_adaptive_card_envelope(message)["attachments"][0]["content"]
+        self.assertEqual("default", content["body"][0]["style"])
+        facts = {fact["title"]: fact["value"] for fact in content["body"][1]["facts"]}
+        self.assertEqual("n/a", facts["Critical"])
+        self.assertEqual("n/a", facts["Unknown"])
+
+    def test_create_notification_message_observation_workflow(self):
+        message = _create_notification_message(
+            "msteams_observation_workflow.tpl",
+            observation=self.observation_1,
+            observation_url="observation_url",
+            first_line="New observation",
+        )
+
+        parsed = self._assert_adaptive_card_envelope(message)
+        content = parsed["attachments"][0]["content"]
+        fact_titles = [fact["title"] for fact in content["body"][1]["facts"]]
+        self.assertEqual(["Product:", "Severity:", "Status:", "Priority:"], fact_titles)
+        self.assertEqual("observation_url", content["actions"][0]["url"])
+
+    def test_create_notification_message_exception_workflow(self):
+        exception = Exception("test_exception")
+        message = _create_notification_message(
+            "msteams_exception_workflow.tpl",
+            exception_class=get_classname(exception),
+            exception_message=str(exception),
+            date_time=datetime(2022, 12, 31, 23, 59, 59),
+            exception_trace="",
+        )
+
+        # Renders to valid JSON even with the date filter inside a string value.
+        self._assert_adaptive_card_envelope(message)
+
+    def test_create_notification_message_observation_workflow_backslash_breakout(self):
+        # The escapejs hardening must hold for the Adaptive Card variant too.
+        self.observation_1.title = 'evil\\", "extra": "x'
+        message = _create_notification_message(
+            "msteams_observation_workflow.tpl",
+            observation=self.observation_1,
+            observation_url="observation_url",
+            first_line='New notification for observation "evil\\", "extra": "x"',
+        )
+        # Parsing must not surface an injected "extra" key in the envelope.
+        parsed = json.loads(message)
+        self.assertEqual({"type", "attachments"}, set(parsed.keys()))
+
+    # --- manual live test ---
+
+    # Skipped in CI: it makes a real HTTP request and posts a card to a channel.
+    # To run it, paste a real Microsoft Teams "Workflows" (Power Automate) webhook
+    # URL into ``live_webhook`` below and remove the @skip decorator. It exercises
+    # detection -> Adaptive Card render -> POST and asserts Power Automate accepts
+    # the request (HTTP 2xx). A 400 "InvalidRequestContent" instead means the body
+    # was not sent as JSON (the bug this change fixes).
+    @unittest.skip("manual live test — set a real Workflows webhook URL and remove this skip to run")
+    def test_live_workflow_webhook_accepts_adaptive_card(self):
+        live_webhook = (
+            "https://<env>.environment.api.powerplatform.com"
+            "/powerautomate/automations/direct/workflows/<workflow-id>"
+            "/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<signature>"
+        )
+        self.assertTrue(_is_msteams_workflow_webhook(live_webhook))
+        template = _get_msteams_workflow_template("msteams_product_security_gate.tpl")
+        message = _create_notification_message(
+            template,
+            product=SimpleNamespace(name="SecObserve live test"),
+            security_gate_status="Passed",
+            product_url="https://github.com/SecObserve/SecObserve",
+        )
+        response = requests.request(
+            method="POST",
+            url=live_webhook,
+            data=message,
+            allow_redirects=False,
+            timeout=60,
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertIn(response.status_code, (200, 202))

--- a/docs/integrations/notifications.md
+++ b/docs/integrations/notifications.md
@@ -35,7 +35,12 @@ An admistrator can configure the field `EXCEPTION_EMAIL_TO` in the [Settings](..
 
 ####  Settings in Microsoft Teams
 
-For both types of notifications an incoming webhook has to be set for a channel, where the notifications shall appear. How to do this is explained in [Create Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook). Copy the URL of the webhook to the clipboard, to have it available to set it in SecObserve.
+A webhook URL has to be set for the channel where the notifications shall appear. Microsoft offers two kinds of channel webhooks and SecObserve supports both — it automatically detects which payload format to send from the webhook URL, so no extra configuration is needed:
+
+* **Workflows (Power Automate):** the current Microsoft offering. Create one with the *"Post to a channel when a webhook request is received"* workflow template, described in [Browse and add workflows in Microsoft Teams](https://support.microsoft.com/en-us/office/browse-and-add-workflows-in-microsoft-teams-4998095c-8b72-4b0e-984c-f2ad39e6ba9a). These URLs contain `/workflows/.../triggers/manual/paths/invoke` in the path (on `*.environment.api.powerplatform.com`, or the older `*.logic.azure.com` form); SecObserve detects them by that path and sends them an Adaptive Card.
+* **Incoming Webhook connector:** the legacy [Office 365 connector](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) (`*.webhook.office.com`). Microsoft has announced the retirement of these connectors, so new channels should use a Workflow instead; existing connector webhooks keep working unchanged (SecObserve sends them a MessageCard).
+
+Copy the URL of the webhook to the clipboard, to have it available to set it in SecObserve.
 
 The messages do not include mentions, but a user can set the "Channel notifications" to "All activities" in Teams, to get an active notification when an entry is generated. 
 


### PR DESCRIPTION
## Summary

SecObserve only sent the legacy MessageCard payload, which the [retired Office 365 Incoming Webhook connector accepts](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/). Microsoft now issues Teams channel webhooks through Workflows (Power Automate), which reject MessageCard and require an Adaptive Card wrapped in a message/attachments envelope.

This PR makes `send_msteams_notification` detect the webhook flavor from the URL and render the payload that endpoint accepts. Existing connector webhooks are unaffected; there is **no model, migration, settings, or frontend change**.

## Backward compatibility

Fully additive and non-breaking:
- Legacy `*.webhook.office.com` webhooks keep receiving the identical `MessageCard` request.
- No database, settings, or UI change; nothing for operators to do on deploy.
- Rollback is a plain revert of the code + new templates.

## Testing

- **Unit tests** (`unittests.notifications.services.test_send_notifications_base`, 26 tests): URL detection by path and by host fallback; `azure-apim.net` consent URL correctly classified as legacy; `send_msteams_notification` selects the `_workflow` template and adds the JSON header for a Workflows URL; legacy connector URL still posts the unchanged `MessageCard` with no extra header; each Adaptive Card template renders to valid JSON with the required envelope; existing escapejs/JSON-injection hardening holds for the new templates.
- **Live smoke test**: rendered each Adaptive Card and POSTed it to a real Power Automate Workflows webhook — **HTTP 202** for both card shapes (security gate and observation).

## Notification Template

<img width="1013" height="1088" alt="Screenshot 2026-06-24 at 15 06 39" src="https://github.com/user-attachments/assets/6cadd860-88ee-4ed2-b09d-631bba6bd7e9" />

