### PR TITLE
fix: rego rule simulation for rules outside interpreter preload cache

### DIFF
--- a/backend/application/rules/services/rule_engine.py
+++ b/backend/application/rules/services/rule_engine.py
@@ -4,6 +4,7 @@ from copy import copy
 from typing import Any, Optional
 
 import jsonpickle
+from jsonpickle.backend import JSONBackend
 
 from application.access_control.services.current_user import get_current_user
 from application.core.models import Observation, Product
@@ -268,10 +269,18 @@ class Rule_Engine:
     def _check_rule_rego(  # pylint: disable=too-many-branches
         self, rule: Rule, observation: Observation, observation_before: Observation, simulation: Optional[bool] = False
     ) -> bool:
-        jsonpickle.set_encoder_options("simplejson", use_decimal=True, sort_keys=True)
-        jsonpickle.set_preferred_backend("simplejson")
+        jsonpickle_backend = JSONBackend()
+        jsonpickle_backend.set_encoder_options("simplejson", use_decimal=True, sort_keys=True)
+        jsonpickle_backend.set_preferred_backend("simplejson")
 
-        observation_dict = json.loads(jsonpickle.dumps(observation, unpicklable=False, use_decimal=True))
+        observation_dict = json.loads(
+            jsonpickle.dumps(
+                observation,
+                unpicklable=False,
+                use_decimal=True,
+                backend=jsonpickle_backend,
+            )
+        )
         observation_dict = {k: v for k, v in observation_dict.items() if v is not None and v != ""}
 
         observation_dict["product_name"] = observation.product.name

--- a/backend/application/rules/services/rule_engine.py
+++ b/backend/application/rules/services/rule_engine.py
@@ -280,7 +280,7 @@ class Rule_Engine:
         if observation.origin_service:
             observation_dict["origin_service_name"] = observation.origin_service.name
 
-        rego_interpreter = self.rego_interpreters[rule.pk]
+        rego_interpreter = self._get_rego_interpreter(rule)
         result = rego_interpreter.query(observation_dict)
 
         new_priority = result.get("priority")
@@ -326,6 +326,14 @@ class Rule_Engine:
             return True
 
         return False
+
+    def _get_rego_interpreter(self, rule: Rule) -> RegoInterpreter:
+        rego_interpreter = self.rego_interpreters.get(rule.pk)
+        if rego_interpreter is None:
+            rego_interpreter = RegoInterpreter(rule.rego_module)
+            self.rego_interpreters[rule.pk] = rego_interpreter
+
+        return rego_interpreter
 
 
 def _check_regex(pattern: str, value: str) -> bool:

--- a/backend/unittests/rules/services/test_rule_engine.py
+++ b/backend/unittests/rules/services/test_rule_engine.py
@@ -1,7 +1,9 @@
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
-from application.core.models import Product
+from application.core.models import Observation, Product
+from application.rules.models import Rule
 from application.rules.services.rule_engine import Rule_Engine, _check_regex
+from application.rules.types import Rule_Type
 from unittests.base_test_case import BaseTestCase
 
 
@@ -53,6 +55,29 @@ class TestRuleEngine(BaseTestCase):
                 ),
             ]
         )
+
+    @patch("application.rules.services.rule_engine.jsonpickle.dumps", return_value="{}")
+    @patch("application.rules.services.rule_engine.RegoInterpreter")
+    @patch("application.rules.models.Rule.objects.filter")
+    def test_check_rule_rego_lazy_loads_interpreter(self, mock_rule, mock_rego_interpreter, _mock_dumps):
+        mock_rule.return_value = []
+        mock_rego_interpreter.return_value.query.return_value = {"severity": "High"}
+        rule_engine = Rule_Engine(self.product_1)
+        rule = Rule(
+            id=1,
+            name="rego_rule",
+            type=Rule_Type.RULE_TYPE_REGO,
+            rego_module="package rule",
+        )
+        observation = Observation(title="observation", product=self.product_1)
+        observation_before = MagicMock(spec=Observation)
+
+        result = rule_engine.check_rule_for_observation(rule, observation, observation_before, True)
+
+        self.assertTrue(result)
+        mock_rego_interpreter.assert_called_once_with("package rule")
+        mock_rego_interpreter.return_value.query.assert_called_once_with({"product_name": "product_1"})
+        self.assertEqual(rule_engine.rego_interpreters[rule.pk], mock_rego_interpreter.return_value)
 
     # --- apply_rules ---
 

--- a/backend/unittests/rules/services/test_rule_engine.py
+++ b/backend/unittests/rules/services/test_rule_engine.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, call, patch
 
+import jsonpickle
+
 from application.core.models import Observation, Product
 from application.rules.models import Rule
 from application.rules.services.rule_engine import Rule_Engine, _check_regex
@@ -71,6 +73,7 @@ class TestRuleEngine(BaseTestCase):
         )
         observation = Observation(title="observation", product=self.product_1)
         observation_before = MagicMock(spec=Observation)
+        jsonpickle_output_before = jsonpickle.dumps({"b": 1, "a": 2}, unpicklable=False)
 
         result = rule_engine.check_rule_for_observation(rule, observation, observation_before, True)
 
@@ -78,6 +81,7 @@ class TestRuleEngine(BaseTestCase):
         mock_rego_interpreter.assert_called_once_with("package rule")
         mock_rego_interpreter.return_value.query.assert_called_once_with({"product_name": "product_1"})
         self.assertEqual(rule_engine.rego_interpreters[rule.pk], mock_rego_interpreter.return_value)
+        self.assertEqual(jsonpickle_output_before, jsonpickle.dumps({"b": 1, "a": 2}, unpicklable=False))
 
     # --- apply_rules ---
 


### PR DESCRIPTION
## Summary

Fixes a `Exception "builtins.KeyError" has occured` when simulating **Rego rules** that are not included in the `Rule_Engine` preload cache.

The rule engine preloads Rego interpreters only for enabled and approved/auto-approved rules. During simulation, however, a selected rule can be evaluated directly even when it is not part of that preload set, such as a general rule awaiting approval. In that case, accessing `self.rego_interpreters[rule.pk]` raised a `KeyError`.

## Context

When we create a rego rule with "General rules need approval" enabled, running the `Simulate` feature triggers an internal error in the backend.

```
│ backend ERROR | 2026-07-07 09:53:23,795 | secobserve.exception_handler | 40 139019856517936 | {'message': '1', 'user': 'xxx', 'request_method': 'POST', 'request_path': '/api/general_rules/1/simulate/', 'request_client_ip': '10 │
│ xxx', 'response_status': '500', 'exception_class': 'builtins.KeyError'}                                                                                                                                                             │
│ backend ERROR | 2026-07-07 09:53:23,799 | secobserve.exception_handler | 40 139019856517936 | Traceback (most recent call last):                                                                                                         │
│ backend   File "/.venv/lib/python3.14/site-packages/rest_framework/views.py", line 512, in dispatch                                                                                                                                      │
│ backend     response = handler(request, *args, **kwargs)                                                                                                                                                                                 │
│ backend   File "/app/application/rules/api/views.py", line 91, in simulate                                                                                                                                                               │
│ backend     return _do_simulation(rule)                                                                                                                                                                                                  │
│ backend   File "/app/application/rules/api/views.py", line 146, in _do_simulation                                                                                                                                                        │
│ backend     num_observations, observations = simulate_rule(rule)                                                                                                                                                                         │
│ backend                                      ~~~~~~~~~~~~~^^^^^^                                                                                                                                                                         │
│ backend   File "/app/application/rules/services/simulator.py", line 69, in simulate_rule                                                                                                                                                 │
│ backend     if rule_engine.check_rule_for_observation(rule, observation, observation_before, True):                                                                                                                                      │
│ backend        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                       │
│ backend   File "/app/application/rules/services/rule_engine.py", line 179, in check_rule_for_observation                                                                                                                                 │
│ backend     rego_found = self._check_rule_rego(rule, observation, observation_before, simulation)                                                                                                                                        │
│ backend   File "/app/application/rules/services/rule_engine.py", line 283, in _check_rule_rego                                                                                                                                           │
│ backend     rego_interpreter = self.rego_interpreters[rule.pk]                                                                                                                                                                           │
│ backend                        ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^                                                                                                                                                                           │
│ backend KeyError: 1                                                                                                                                                                                                                      │
```

## Changes

- Added lazy loading for Rego interpreters when a simulated rule is missing from the cache.
- Reused the lazy-loaded interpreter for subsequent observations in the same rule engine instance.
- Added a regression test for simulating a Rego rule when the preload cache is empty.