### PR TITLE
fix: derive CSAF relationship and product-tree ids consistently

### DIFF
--- a/backend/application/vex/services/csaf_generator_component.py
+++ b/backend/application/vex/services/csaf_generator_component.py
@@ -4,6 +4,7 @@ from packageurl import PackageURL
 
 from application.core.models import Observation
 from application.vex.services.csaf_generator_helpers import (
+    get_component_id,
     get_product_id,
     get_relationship_name,
 )
@@ -16,14 +17,6 @@ from application.vex.types import (
     CSAFProductRelationship,
     CSAFProductTree,
 )
-
-
-def get_component_id(component_name_version: str, purl: Optional[str], cpe: Optional[str]) -> str:
-    if purl:
-        return purl
-    if cpe:
-        return cpe
-    return component_name_version
 
 
 def append_component_to_product_tree(

--- a/backend/application/vex/services/csaf_generator_helpers.py
+++ b/backend/application/vex/services/csaf_generator_helpers.py
@@ -60,12 +60,22 @@ def get_product_id(product: Product, branch: Optional[Branch]) -> str:
     return product.name
 
 
+def get_component_id(component_name_version: str, purl: Optional[str], cpe: Optional[str]) -> str:
+    if purl:
+        return purl
+    if cpe:
+        return cpe
+    return component_name_version
+
+
 def get_relationship_name(observation: Observation) -> str:
-    relationship_name = f"{observation.origin_component_name_version}@"
-    relationship_name += (
-        f"{observation.product.name}:{observation.branch.name}" if observation.branch else observation.product.name
+    component_id = get_component_id(
+        observation.origin_component_name_version,
+        observation.origin_component_purl,
+        observation.origin_component_cpe,
     )
-    return relationship_name
+    product_id = get_product_id(observation.product, observation.branch)
+    return f"{component_id}@{product_id}"
 
 
 def get_product_or_relationship_id(observation: Observation) -> str:

--- a/backend/application/vex/services/csaf_generator_product.py
+++ b/backend/application/vex/services/csaf_generator_product.py
@@ -30,11 +30,13 @@ def append_product_to_product_tree(
         )
         product_tree.branches.append(product_family_branch)
 
+    product_id = get_product_id(product, branch)
+
     if not branch:
         if product_family_branch.branches is None:
             raise ValueError("Product family branches should not be None")
         for product_name_branch in product_family_branch.branches:
-            if product_name_branch.name == product.name:
+            if product_name_branch.product and product_name_branch.product.product_id == product_id:
                 return
 
         new_product_full_name = _create_product(product, branch)
@@ -48,7 +50,7 @@ def append_product_to_product_tree(
         if product_family_branch.branches is None:
             raise ValueError("Product family branches should not be None")
         for version_branch in product_family_branch.branches:
-            if version_branch.name == f"{product.name}:{branch.name}":
+            if version_branch.product and version_branch.product.product_id == product_id:
                 return
 
         new_product_full_name = _create_product(product, branch)

--- a/backend/unittests/vex/api/files/csaf_given_vulnerability.json
+++ b/backend/unittests/vex/api/files/csaf_given_vulnerability.json
@@ -120,8 +120,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_1",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_1"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -129,8 +129,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_2:dev",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_2:dev"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@dev"
@@ -138,8 +138,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_4:4.0.0@vex_product_2:dev",
-                    "product_id": "vex_comp_4:4.0.0@vex_product_2:dev"
+                    "name": "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev",
+                    "product_id": "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev"
                 },
                 "product_reference": "pkg:so/vex_comp_4@4.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@dev"
@@ -157,10 +157,10 @@
             ],
             "product_status": {
                 "known_affected": [
-                    "vex_comp_2:2.0.0@vex_product_2:dev"
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                 ],
                 "under_investigation": [
-                    "vex_comp_2:2.0.0@vex_product_1"
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 ]
             },
             "references": [
@@ -175,7 +175,7 @@
                     "category": "mitigation",
                     "details": "Upgrade to release 2.1.0",
                     "product_ids": [
-                        "vex_comp_2:2.0.0@vex_product_2:dev"
+                        "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                     ]
                 }
             ]

--- a/backend/unittests/vex/api/files/csaf_given_vulnerability_update.json
+++ b/backend/unittests/vex/api/files/csaf_given_vulnerability_update.json
@@ -125,8 +125,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_1",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_1"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -134,8 +134,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_2:dev",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_2:dev"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@dev"
@@ -143,8 +143,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_4:4.0.0@vex_product_2:dev",
-                    "product_id": "vex_comp_4:4.0.0@vex_product_2:dev"
+                    "name": "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev",
+                    "product_id": "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev"
                 },
                 "product_reference": "pkg:so/vex_comp_4@4.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@dev"
@@ -162,8 +162,8 @@
             ],
             "product_status": {
                 "known_affected": [
-                    "vex_comp_2:2.0.0@vex_product_1",
-                    "vex_comp_2:2.0.0@vex_product_2:dev"
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1",
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                 ]
             },
             "references": [
@@ -178,8 +178,8 @@
                     "category": "mitigation",
                     "details": "Upgrade to release 2.1.0",
                     "product_ids": [
-                        "vex_comp_2:2.0.0@vex_product_1",
-                        "vex_comp_2:2.0.0@vex_product_2:dev"
+                        "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1",
+                        "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                     ]
                 }
             ]

--- a/backend/unittests/vex/api/files/csaf_product_branches.json
+++ b/backend/unittests/vex/api/files/csaf_product_branches.json
@@ -131,8 +131,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_2:dev",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_2:dev"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@dev"
@@ -140,8 +140,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_4:4.0.0@vex_product_2:dev",
-                    "product_id": "vex_comp_4:4.0.0@vex_product_2:dev"
+                    "name": "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev",
+                    "product_id": "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev"
                 },
                 "product_reference": "pkg:so/vex_comp_4@4.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@dev"
@@ -149,8 +149,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_5:5.0.0@vex_product_2:main",
-                    "product_id": "vex_comp_5:5.0.0@vex_product_2:main"
+                    "name": "vex_comp_5:5.0.0@pkg:so/vex_product_2@main",
+                    "product_id": "vex_comp_5:5.0.0@pkg:so/vex_product_2@main"
                 },
                 "product_reference": "vex_comp_5:5.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@main"
@@ -168,7 +168,7 @@
             ],
             "product_status": {
                 "known_affected": [
-                    "vex_comp_2:2.0.0@vex_product_2:dev"
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                 ]
             },
             "references": [
@@ -183,7 +183,7 @@
                     "category": "mitigation",
                     "details": "Upgrade to release 2.1.0",
                     "product_ids": [
-                        "vex_comp_2:2.0.0@vex_product_2:dev"
+                        "pkg:so/vendor2/vex_comp_2@2.0.0@pkg:so/vex_product_2@dev"
                     ]
                 }
             ]
@@ -203,7 +203,7 @@
             ],
             "product_status": {
                 "fixed": [
-                    "vex_comp_4:4.0.0@vex_product_2:dev"
+                    "pkg:so/vex_comp_4@4.0.0@pkg:so/vex_product_2@dev"
                 ]
             }
         },
@@ -222,7 +222,7 @@
             ],
             "product_status": {
                 "known_not_affected": [
-                    "vex_comp_5:5.0.0@vex_product_2:main"
+                    "vex_comp_5:5.0.0@pkg:so/vex_product_2@main"
                 ]
             },
             "threats": [
@@ -230,7 +230,7 @@
                     "category": "impact",
                     "details": "Should be no problem",
                     "product_ids": [
-                        "vex_comp_5:5.0.0@vex_product_2:main"
+                        "vex_comp_5:5.0.0@pkg:so/vex_product_2@main"
                     ]
                 }
             ]

--- a/backend/unittests/vex/api/files/csaf_product_given_branch.json
+++ b/backend/unittests/vex/api/files/csaf_product_given_branch.json
@@ -78,8 +78,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_5:5.0.0@vex_product_2:main",
-                    "product_id": "vex_comp_5:5.0.0@vex_product_2:main"
+                    "name": "vex_comp_5:5.0.0@pkg:so/vex_product_2@main",
+                    "product_id": "vex_comp_5:5.0.0@pkg:so/vex_product_2@main"
                 },
                 "product_reference": "vex_comp_5:5.0.0",
                 "relates_to_product_reference": "pkg:so/vex_product_2@main"
@@ -102,7 +102,7 @@
             ],
             "product_status": {
                 "known_not_affected": [
-                    "vex_comp_5:5.0.0@vex_product_2:main"
+                    "vex_comp_5:5.0.0@pkg:so/vex_product_2@main"
                 ]
             },
             "threats": [
@@ -110,7 +110,7 @@
                     "category": "impact",
                     "details": "Should be no problem",
                     "product_ids": [
-                        "vex_comp_5:5.0.0@vex_product_2:main"
+                        "vex_comp_5:5.0.0@pkg:so/vex_product_2@main"
                     ]
                 }
             ]

--- a/backend/unittests/vex/api/files/csaf_product_no_branch.json
+++ b/backend/unittests/vex/api/files/csaf_product_no_branch.json
@@ -127,8 +127,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_1:1.0.0@vex_product_1",
-                    "product_id": "vex_comp_1:1.0.0@vex_product_1"
+                    "name": "pkg:so/vex_comp_1@1.0.0@vex_product_1",
+                    "product_id": "pkg:so/vex_comp_1@1.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vex_comp_1@1.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -136,8 +136,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_1",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_1"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -145,8 +145,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_3:3.0.0@vex_product_1",
-                    "product_id": "vex_comp_3:3.0.0@vex_product_1"
+                    "name": "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1",
+                    "product_id": "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vendor_3/vex_comp_3@3.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -169,7 +169,7 @@
             ],
             "product_status": {
                 "known_affected": [
-                    "vex_comp_1:1.0.0@vex_product_1"
+                    "pkg:so/vex_comp_1@1.0.0@vex_product_1"
                 ]
             },
             "references": [
@@ -184,7 +184,7 @@
                     "category": "mitigation",
                     "details": "Upgrade to release 1.1.0",
                     "product_ids": [
-                        "vex_comp_1:1.0.0@vex_product_1"
+                        "pkg:so/vex_comp_1@1.0.0@vex_product_1"
                     ]
                 }
             ]
@@ -199,7 +199,7 @@
             ],
             "product_status": {
                 "under_investigation": [
-                    "vex_comp_2:2.0.0@vex_product_1"
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 ]
             },
             "references": [
@@ -215,7 +215,7 @@
                 {
                     "label": "vulnerable_code_not_in_execute_path",
                     "product_ids": [
-                        "vex_comp_3:3.0.0@vex_product_1"
+                        "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1"
                     ]
                 }
             ],
@@ -233,7 +233,7 @@
             ],
             "product_status": {
                 "known_not_affected": [
-                    "vex_comp_3:3.0.0@vex_product_1"
+                    "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1"
                 ]
             }
         }

--- a/backend/unittests/vex/api/files/csaf_product_no_branch_update.json
+++ b/backend/unittests/vex/api/files/csaf_product_no_branch_update.json
@@ -132,8 +132,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_1:1.0.0@vex_product_1",
-                    "product_id": "vex_comp_1:1.0.0@vex_product_1"
+                    "name": "pkg:so/vex_comp_1@1.0.0@vex_product_1",
+                    "product_id": "pkg:so/vex_comp_1@1.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vex_comp_1@1.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -141,8 +141,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_2:2.0.0@vex_product_1",
-                    "product_id": "vex_comp_2:2.0.0@vex_product_1"
+                    "name": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1",
+                    "product_id": "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vendor2/vex_comp_2@2.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -150,8 +150,8 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
-                    "name": "vex_comp_3:3.0.0@vex_product_1",
-                    "product_id": "vex_comp_3:3.0.0@vex_product_1"
+                    "name": "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1",
+                    "product_id": "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1"
                 },
                 "product_reference": "pkg:so/vendor_3/vex_comp_3@3.0.0",
                 "relates_to_product_reference": "vex_product_1"
@@ -174,7 +174,7 @@
             ],
             "product_status": {
                 "known_affected": [
-                    "vex_comp_1:1.0.0@vex_product_1"
+                    "pkg:so/vex_comp_1@1.0.0@vex_product_1"
                 ]
             },
             "references": [
@@ -189,7 +189,7 @@
                     "category": "mitigation",
                     "details": "Upgrade to release 1.1.0",
                     "product_ids": [
-                        "vex_comp_1:1.0.0@vex_product_1"
+                        "pkg:so/vex_comp_1@1.0.0@vex_product_1"
                     ]
                 }
             ]
@@ -204,7 +204,7 @@
             ],
             "product_status": {
                 "known_affected": [
-                    "vex_comp_2:2.0.0@vex_product_1"
+                    "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                 ]
             },
             "references": [
@@ -219,7 +219,7 @@
                     "category": "mitigation",
                     "details": "Upgrade to release 2.1.0",
                     "product_ids": [
-                        "vex_comp_2:2.0.0@vex_product_1"
+                        "pkg:so/vendor2/vex_comp_2@2.0.0@vex_product_1"
                     ]
                 }
             ]
@@ -229,7 +229,7 @@
                 {
                     "label": "vulnerable_code_not_in_execute_path",
                     "product_ids": [
-                        "vex_comp_3:3.0.0@vex_product_1"
+                        "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1"
                     ]
                 }
             ],
@@ -247,7 +247,7 @@
             ],
             "product_status": {
                 "known_not_affected": [
-                    "vex_comp_3:3.0.0@vex_product_1"
+                    "pkg:so/vendor_3/vex_comp_3@3.0.0@vex_product_1"
                 ]
             }
         }

--- a/backend/unittests/vex/api/test_views_csaf.py
+++ b/backend/unittests/vex/api/test_views_csaf.py
@@ -80,7 +80,7 @@ class TestCSAF(TestCase):
         self.assertEqual(Product.objects.get(id=1), csaf.product)
         self.assertEqual(1, csaf.version)
         self.assertEqual(
-            "eaa6cdcec3ea5f1feff8ecd7d0c8802e027e5c26d34f57f7a8cb0f31f633da0a",
+            "d95a991952c7a926d90e2beadcbd5d691e740f599df95470f1a4615b0a1d0470",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)
@@ -170,7 +170,7 @@ class TestCSAF(TestCase):
         self.assertEqual(Product.objects.get(id=1), csaf.product)
         self.assertEqual(2, csaf.version)
         self.assertEqual(
-            "65aeaea7aa45c945515b81613bd0a937b2f2262a9a6dfc0512bbde340c67aad1",
+            "d4d235a598370dfaa825172c73663acdc5dd5b55b3dc676f6ac22f48a0b7c3fb",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)
@@ -254,7 +254,7 @@ class TestCSAF(TestCase):
         self.assertEqual(Product.objects.get(id=2), csaf.product)
         self.assertEqual(1, csaf.version)
         self.assertEqual(
-            "ad81aa72d9cd265574eef05a13f86e6c7072212532b2d167e3ca120b6d26b897",
+            "17dcf310dc70fcfde16c7fce6560fa950f8307c15dff66226460f32e6166a8be",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)
@@ -339,7 +339,7 @@ class TestCSAF(TestCase):
         self.assertEqual(Product.objects.get(id=2), csaf.product)
         self.assertEqual(1, csaf.version)
         self.assertEqual(
-            "cf643f6b631cf5d2bf9a11b0c7247d1be9e456482e9fc9ed073c8b3823d8bd0d",
+            "7eab73b134c451d9f8a73dbe52346aca0dde97aa3c22ec8cf647a656ab76e25b",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)
@@ -424,7 +424,7 @@ class TestCSAF(TestCase):
         self.assertEqual(None, csaf.product)
         self.assertEqual(1, csaf.version)
         self.assertEqual(
-            "191a9c71fc1f1ab976b5d45adeedbc1faf997c43d59ab4977b907b95a9ab003d",
+            "e7444a7013ee24938b6757183d76ab87aa49921508bd1a5980fb64ff30b78a2b",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)
@@ -511,7 +511,7 @@ class TestCSAF(TestCase):
         self.assertEqual(None, csaf.product)
         self.assertEqual(2, csaf.version)
         self.assertEqual(
-            "25495e803982bde094cd1f337f48c9740cd0250f0b04a9c5af3a6cdb72640184",
+            "578b26be2b54431bd004ce9828775023ebcfb45f5365f1daab6c5212061b123b",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)


### PR DESCRIPTION
The product ids used inside relationship entries of the product tree were derived differently from the ids used everywhere else in the document:

- The component side of a relationship (`product_reference`) and the product side (`relates_to_product_reference`) use the PURL/CPE-based ids from `get_component_id()` / `get_product_id()`.
- The relationship's own `full_product_name.product_id` (which `product_status`, `flags`, `threats` and `remediations` reference) was built from `origin_component_name_version` and the product/branch *names* instead.

This is inconsistent and can produce invalid documents: two different components that share the same name and version but have different PURLs (or two products/branches whose names collide) end up as two relationship entries with the same `product_id`, which violates the uniqueness requirement for product ids and attributes statuses to the wrong product.