### PR TITLE
fix: get CSAF products from relationships as well

### DIFF
--- a/backend/application/vex/services/csaf_parser.py
+++ b/backend/application/vex/services/csaf_parser.py
@@ -27,6 +27,7 @@ def parse_csaf_data(data: dict) -> None:
     product_tree: dict = data.get("product_tree", {})
     _find_products_in_branches(product_tree.get("branches", []), products)
     _find_products_in_full_product_names(product_tree.get("full_product_names", []), products)
+    _find_products_in_relationships(product_tree.get("relationships", []), products)
 
     relationships: dict[str, Relationship] = _process_relationships(product_tree)
 
@@ -88,6 +89,13 @@ def _find_products_in_branches(branches: list, products: dict[str, str]) -> None
 def _find_products_in_full_product_names(full_product_names: list, products: dict[str, str]) -> None:
     for product in full_product_names:
         _process_product(product, products)
+
+
+def _find_products_in_relationships(relationships: list, products: dict[str, str]) -> None:
+    for relationship in relationships:
+        full_product_name = relationship.get("full_product_name")
+        if full_product_name:
+            _process_product(full_product_name, products)
 
 
 def _process_product(product: dict, products: dict[str, str]) -> None:


### PR DESCRIPTION
When importing a CSAF document, products were only collected from `product_tree/branches` and `product_tree/full_product_names`. Products that are defined by a relationship's `full_product_name` (the common case for `default_component_of` relationships, and what SecObserve's own CSAF export produces) were not collected, so VEX statements referencing those product ids could not be resolved.