### PR TITLE
fix: support ARM64 development on macOS

### DIFF
--- a/docker-compose-dev-arm.yaml
+++ b/docker-compose-dev-arm.yaml
@@ -1,0 +1,18 @@
+# Docker Compose override for development on macOS with Apple Silicon.
+# Usage: docker compose -f docker-compose-dev.yml -f docker-compose-dev-arm.yaml up --build
+
+services:
+  frontend:
+    platform: linux/arm64/v8
+    volumes:
+      - dev_node_modules:/app/node_modules
+    command: sh -c "npm install --no-audit --no-fund && npm run start -- --host"
+
+  backend:
+    platform: linux/arm64/v8
+
+  postgres:
+    platform: linux/arm64/v8
+
+volumes:
+  dev_node_modules:

--- a/docs/development/docker_compose.md
+++ b/docs/development/docker_compose.md
@@ -14,6 +14,14 @@ Docker Compose is a tool for defining and running multi-container Docker applica
 * [`docker-compose-dev.yml`](https://github.com/SecObserve/SecObserve/blob/dev/docker-compose-dev.yml)
     - Starts the PostgreSQL database, as well as SecObserve's backend and frontend
     - Backend and frontend are build automatically if necessary and are started in development mode with hot reloading
+* [`docker-compose-dev-arm.yaml`](https://github.com/SecObserve/SecObserve/blob/dev/docker-compose-dev-arm.yaml)
+    - Overrides the development stack for macOS on Apple Silicon
+    - Runs the main services on ARM64 and installs frontend dependencies inside the container using a Docker-managed volume
+    - Start it together with the standard development file:
+
+      ```shell
+      docker compose -f docker-compose-dev.yml -f docker-compose-dev-arm.yaml up --build
+      ```
 * [`docker-compose-playwright.yml`](https://github.com/SecObserve/SecObserve/blob/dev/docker-compose-playwright.yml)
     - Starts the end-to-end tests with Playwright
 * [`docker-compose-prod-test.yml`](https://github.com/SecObserve/SecObserve/blob/dev/docker-compose-prod-test.yml)


### PR DESCRIPTION
## Summary

- Add a small Compose override for macOS on Apple Silicon.
- Run the frontend, backend, and PostgreSQL services on native ARM64.
- Keep frontend `node_modules` in Docker and document the startup command.

## Logic

The source code remains bind-mounted for hot reload, while `/app/node_modules` is shadowed by a Docker-managed volume. Dependencies are therefore installed inside the Linux container instead of reusing incompatible macOS packages. Explicit service platforms also override a conflicting host-level platform default.

## Testing

- Built and started the complete stack on Apple Silicon.
- Verified frontend, backend, and PostgreSQL run on ARM64; Node reports `linux/arm64`.
- Verified frontend and backend health endpoints return HTTP 200.
- Verified ARM64 still resolves when `DOCKER_DEFAULT_PLATFORM=linux/amd64` is set.

Fixes #4536