### PR TITLE
fix: correct OIDC_AUTHORITY documentation for Microsoft Entra ID

### DIFF
--- a/docs/integrations/oidc_authentication.md
+++ b/docs/integrations/oidc_authentication.md
@@ -1,6 +1,6 @@
 # OpenID Connect authentication
 
-[OpenID Connect](https://openid.net/developers/how-connect-works) authentication has been tested with Keycloak and Azure Active Directory. It should work with other OpenID Connect providers as well, as long as they support the [authorization flow](https://oauth.net/2/grant-types/authorization-code) with [PKCE](https://oauth.net/2/pkce) and without a secret.
+[OpenID Connect](https://openid.net/developers/how-connect-works) authentication has been tested with Keycloak and Microsoft Entra ID. It should work with other OpenID Connect providers as well, as long as they support the [authorization flow](https://oauth.net/2/grant-types/authorization-code) with [PKCE](https://oauth.net/2/pkce) and without a secret.
 
 ## Keycloak
 
@@ -8,9 +8,9 @@ In Keycloak a new OpenID Connect client needs to be created. The client needs to
 
 ![Keycloak client settings](../assets/images/screenshot_keycloak.png)
 
-#### Configuration parameters for SecObserve
+### Configuration parameters for SecObserve
 
-Backend
+Backend:
 
 | Environment variable | Value                                               |
 |----------------------|-----------------------------------------------------|
@@ -23,7 +23,7 @@ Backend
 | `OIDC_GROUPS`        | `groups`                                            |
 
 
-Frontend
+Frontend:
 
 | Environment variable            | Value                                               |
 |---------------------------------|-----------------------------------------------------|
@@ -35,13 +35,13 @@ Frontend
 | `OIDC_PROMPT`                   | [no value]                                          |
 
 
-## Azure Active Directory
+## Microsoft Entra ID
 
-In Azure Active Directory a new App registration needs to be created.
+In Microsoft Entra ID, a new **App registration** needs to be created, with the redirect URI registered under the **Single-page application (SPA)** platform. A client secret is not needed.
 
-#### Configuration parameters for SecObserve
+### Configuration parameters for SecObserve
 
-Backend
+Backend:
 
 | Environment variable | Value                                              |
 |----------------------|----------------------------------------------------|
@@ -53,17 +53,16 @@ Backend
 | `OIDC_GROUPS`        | `groups`                                           |
 
 
-Frontend
+Frontend:
 
 | Environment variable            | Value                                              |
 |---------------------------------|----------------------------------------------------|
 | `OIDC_ENABLE`                   | `true`                                             |
-| `OIDC_AUTHORITY`                | `https://login.microsoftonline.com/TENANT_ID`      |
+| `OIDC_AUTHORITY`                | `https://login.microsoftonline.com/TENANT_ID/v2.0` |
 | `OIDC_CLIENT_ID`                | `CLIENT_ID`                                        |
 | `OIDC_REDIRECT_URI`             | `https://secobserve.example.com`                   |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | `https://secobserve.example.com`                   |
 | `OIDC_PROMPT`                   | [no value]                                         |
-
 
 ## Customize the login dialog
 


### PR DESCRIPTION
## Problem

The documentation for Microsoft Entra ID (formerly Azure Active Directory) lists the frontend `OIDC_AUTHORITY` as `https://login.microsoftonline.com/TENANT_ID` without the `/v2.0` suffix while the backend table includes the suffix.

Without `/v2.0`, `https://login.microsoftonline.com/TENANT_ID/.well-known/openid-configuration` serves the discovery document of the legacy v1.0 endpoints (issuer `https://sts.windows.net/...`). ID tokens issued by the v1.0 endpoints do not contain the `preferred_username` claim, so authentication in the backend fails with `No username found in JWT`. Both frontend and backend need `https://login.microsoftonline.com/TENANT_ID/v2.0`.

## Changes

- Corrected the frontend `OIDC_AUTHORITY` value for Microsoft Entra ID (added the `/v2.0` suffix, consistent with the backend table)
- Documented that the redirect URI must be registered under the **Single-page application (SPA)** platform of the App registration and that no client secret is needed. With the Web platform, the login fails with `AADSTS9002326: Cross-origin token redemption is permitted only for the 'Single-Page Application' client-type.`
- Renamed "Azure Active Directory" to its current name "Microsoft Entra ID"
- Minor formatting consistency in the Keycloak/Entra ID configuration sections

Documentation only change, no code affected. Tested against my real Microsoft Entra ID tenant