### PR TITLE
fix: OpenVEX export for identical statements on multiple branches

### DIFF
--- a/backend/application/vex/services/openvex_generator.py
+++ b/backend/application/vex/services/openvex_generator.py
@@ -270,7 +270,8 @@ def _get_statements_for_product(
             if existing_product:
                 _add_subcomponent(observation, existing_product)
             else:
-                raise ValueError(f"Product {product.name} not found in existing statement")
+                openvex_product = _create_product(observation)
+                existing_statement.products.append(openvex_product)
         else:
             prepared_statement.vulnerability = openvex_vulnerability
             openvex_product = _create_product(observation)

--- a/backend/unittests/vex/api/files/openvex_product_same_statement_on_multiple_branches.json
+++ b/backend/unittests/vex/api/files/openvex_product_same_statement_on_multiple_branches.json
@@ -1,0 +1,81 @@
+{
+    "@context": "https://openvex.dev/ns/v0.2.0",
+    "@id": "https://vex.example.com/OpenVEX_2020_0001",
+    "author": "Author",
+    "last_updated": "2020-01-01T04:30:00+00:00",
+    "role": "Role",
+    "statements": [
+        {
+            "action_statement": "Upgrade to release 2.1.0",
+            "products": [
+                {
+                    "@id": "pkg:so/vex_product_2@dev",
+                    "identifiers": {
+                        "purl": "pkg:so/vex_product_2@dev"
+                    },
+                    "subcomponents": [
+                        {
+                            "@id": "pkg:so/vendor2/vex_comp_2@2.0.0"
+                        }
+                    ]
+                },
+                {
+                    "@id": "pkg:so/vex_product_2@main",
+                    "identifiers": {
+                        "purl": "pkg:so/vex_product_2@main"
+                    },
+                    "subcomponents": [
+                        {
+                            "@id": "pkg:so/vendor2/vex_comp_2@2.0.0"
+                        }
+                    ]
+                }
+            ],
+            "status": "affected",
+            "vulnerability": {
+                "@id": "https://nvd.nist.gov/vuln/detail/CVE-vulnerability_2",
+                "description": "description 2",
+                "name": "CVE-vulnerability_2"
+            }
+        },
+        {
+            "products": [
+                {
+                    "@id": "pkg:so/vex_product_2@dev",
+                    "identifiers": {
+                        "purl": "pkg:so/vex_product_2@dev"
+                    },
+                    "subcomponents": [
+                        {
+                            "@id": "pkg:so/vex_comp_4@4.0.0"
+                        }
+                    ]
+                }
+            ],
+            "status": "fixed",
+            "vulnerability": {
+                "description": "description 3",
+                "name": "vex_vulnerability_3"
+            }
+        },
+        {
+            "impact_statement": "Should be no problem",
+            "products": [
+                {
+                    "@id": "pkg:so/vex_product_2@main",
+                    "identifiers": {
+                        "purl": "pkg:so/vex_product_2@main"
+                    }
+                }
+            ],
+            "status": "not_affected",
+            "vulnerability": {
+                "description": "description 4",
+                "name": "vex_vulnerability_4"
+            }
+        }
+    ],
+    "timestamp": "2020-01-01T04:30:00+00:00",
+    "tooling": "SecObserve / 1.57.0",
+    "version": 1
+}

--- a/backend/unittests/vex/api/test_views_openvex.py
+++ b/backend/unittests/vex/api/test_views_openvex.py
@@ -7,7 +7,7 @@ from django.utils import dateparse
 from rest_framework.test import APIClient
 
 from application.access_control.models import User
-from application.core.models import Observation, Product, Product_Member
+from application.core.models import Branch, Observation, Product, Product_Member
 from application.licenses.models import License_Component
 from application.vex.models import OpenVEX, OpenVEX_Branch, OpenVEX_Vulnerability
 
@@ -232,6 +232,54 @@ class TestOpenVEX(TestCase):
 
         openvex_vulnerabilities = OpenVEX_Vulnerability.objects.filter(openvex=openvex)
         self.assertEqual(0, len(openvex_vulnerabilities))
+
+    @patch("django.utils.timezone.now")
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    @patch("application.vex.services.openvex_generator.user_has_permission_or_403")
+    @patch("application.vex.services.openvex_generator.get_current_user")
+    @patch("application.core.queries.observation.get_current_user")
+    def test_openvex_document_product_same_statement_on_multiple_branches(
+        self,
+        mock_get_current_user_1,
+        mock_get_current_user_2,
+        mock_get_user_has_permission_or_403,
+        mock_authenticate,
+        mock_now,
+    ):
+        mock_now.return_value = dateparse.parse_datetime("2020-01-01T04:30:00Z")
+        vex_user = User.objects.get(username="vex_user")
+        mock_authenticate.return_value = vex_user, None
+        mock_get_current_user_1.return_value = vex_user
+        mock_get_current_user_2.return_value = vex_user
+
+        # same vulnerability with the same status on a second branch
+        observation = Observation.objects.get(id=4)
+        observation.pk = None
+        observation.branch = Branch.objects.get(id=2)
+        observation.save()
+
+        parameters = {
+            "product": 2,
+            "document_id_prefix": "OpenVEX",
+            "id_namespace": "https://vex.example.com",
+            "author": "Author",
+            "role": "Role",
+        }
+
+        api_client = APIClient()
+        response = api_client.post("/api/vex/openvex_document/create/", parameters, format="json")
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/json", response.headers["Content-Type"])
+        self.assertEqual(
+            "attachment; filename=OpenVEX_2020_0001_0001.json",
+            response.headers["Content-Disposition"],
+        )
+        with open(
+            path.dirname(__file__) + "/files/openvex_product_same_statement_on_multiple_branches.json",
+            "r",
+        ) as testfile:
+            self.assertEqual(testfile.read(), response._container[0].decode("utf-8"))
 
     @patch("django.utils.timezone.now")
     @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")


### PR DESCRIPTION
## Problem

`POST /api/vex/openvex_document/create/` returned HTTP 500 with `ValueError: Product <name> not found in existing statement` whenever the selected product had observations of the same vulnerability with the same status/justification/notes on two or more branches.

## Fix

In `_get_statements_for_product`, when an observation maps to an existing statement but its OpenVEX product id (`name:branch`) is not yet part of that statement, append the branch as an additional product instead of raising. This mirrors how `_get_statements_for_vulnerabilities` already handles the same case.

Since branches are distinct OpenVEX products, a multi-branch product hitting the same statement hash is a normal state, not an error.

## Tests

Added `test_openvex_document_product_same_statement_on_multiple_branches`, which clones an existing observation onto a second branch and verifies the generated document lists both branches as products of the shared statement. The test fails with HTTP 500 without the fix.

Full unit test suite, black, isort, flake8, mypy, pylint and import-linter pass.

Closes #4671