### PR TITLE
feat: search users by username in addition to full name in user popups

### DIFF
--- a/backend/application/access_control/api/views.py
+++ b/backend/application/access_control/api/views.py
@@ -90,7 +90,7 @@ class UserViewSet(ModelViewSet):
     queryset = User.objects.none()
     permission_classes = (IsAuthenticated, UserHasSuperuserPermission)
     filter_backends = [SearchFilter, DjangoFilterBackend]
-    search_fields = ["full_name"]
+    search_fields = ["full_name", "username"]
 
     def get_queryset(self) -> QuerySet[User]:
         if self.action == "list":

--- a/frontend/src/access_control/authorization_group_members/AuthorizationGroupMemberAdd.tsx
+++ b/frontend/src/access_control/authorization_group_members/AuthorizationGroupMemberAdd.tsx
@@ -7,6 +7,7 @@ import AddButton from "../../commons/custom_fields/AddButton";
 import CancelButton from "../../commons/custom_fields/CancelButton";
 import Toolbar from "../../commons/custom_fields/Toolbar";
 import { validate_required } from "../../commons/custom_validators";
+import { getUserOptionText } from "../../commons/functions";
 import { AutocompleteInputWide } from "../../commons/layout/themes";
 import { httpClient } from "../../commons/ra-data-django-rest-framework";
 
@@ -102,7 +103,7 @@ const AuthorizationGroupMemberAdd = ({ id }: AuthorizationGroupMemberAddProps) =
                             sort={{ field: "full_name", order: "ASC" }}
                         >
                             <AutocompleteInputWide
-                                optionText="full_name"
+                                optionText={getUserOptionText}
                                 validate={validate_required}
                                 onChange={(e) => setUser(e)}
                             />

--- a/frontend/src/commons/custom_fields/DesignatedApproversInput.tsx
+++ b/frontend/src/commons/custom_fields/DesignatedApproversInput.tsx
@@ -1,9 +1,11 @@
 import { Identifier, RaRecord, useGetList } from "react-admin";
 
+import { getUserOptionText } from "../functions";
 import { AutocompleteArrayInputWide } from "../layout/themes";
 
 interface UserRecord extends RaRecord {
     full_name: string;
+    username: string;
 }
 
 interface DesignatedApproversInputProps {
@@ -24,11 +26,15 @@ export const DesignatedApproversInput = ({ approver_filter, helperText }: Design
             label="Designated approvers"
             helperText={helperText}
             choices={data ?? []}
-            optionText="full_name"
-            inputText={(record: RaRecord) => (record as UserRecord).full_name}
-            matchSuggestion={(filterValue: string, record: RaRecord) =>
-                (record as UserRecord).full_name.toLowerCase().includes(filterValue.toLowerCase())
-            }
+            optionText={getUserOptionText}
+            inputText={(record: RaRecord) => getUserOptionText(record)}
+            matchSuggestion={(filterValue: string, record: RaRecord) => {
+                const user = record as UserRecord;
+                return (
+                    user.full_name.toLowerCase().includes(filterValue.toLowerCase()) ||
+                    (user.username ?? "").toLowerCase().includes(filterValue.toLowerCase())
+                );
+            }}
         />
     );
 };

--- a/frontend/src/commons/functions.tsx
+++ b/frontend/src/commons/functions.tsx
@@ -1,5 +1,5 @@
 import { PackageURL } from "packageurl-js";
-import { SortPayload } from "ra-core";
+import { RaRecord, SortPayload } from "ra-core";
 import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 import { httpClient } from "../commons/ra-data-django-rest-framework";
@@ -36,6 +36,13 @@ export function getIconAndFontColor() {
     } else {
         return "black";
     }
+}
+
+export function getUserOptionText(user: RaRecord): string {
+    if (user.username && user.username !== user.full_name) {
+        return `${user.full_name} (${user.username})`;
+    }
+    return user.full_name;
 }
 
 export function get_severity_color(severity: string): string {

--- a/frontend/src/commons/functions.tsx
+++ b/frontend/src/commons/functions.tsx
@@ -39,7 +39,7 @@ export function getIconAndFontColor() {
 }
 
 export function getUserOptionText(user: RaRecord): string {
-    if (user.username && user.username !== user.full_name) {
+    if (user.full_name && user.username !== user.full_name) {
         return `${user.full_name} (${user.username})`;
     }
     return user.full_name;

--- a/frontend/src/core/observation_logs/ObservationLogApprovalList.tsx
+++ b/frontend/src/core/observation_logs/ObservationLogApprovalList.tsx
@@ -24,7 +24,7 @@ import { ProductGroupReferenceInput } from "../../commons/custom_fields/ProductG
 import { ProductReferenceInput } from "../../commons/custom_fields/ProductReferenceInput";
 import { ServiceReferenceInput } from "../../commons/custom_fields/ServiceReferenceInput";
 import { SeverityField } from "../../commons/custom_fields/SeverityField";
-import { feature_vex_enabled, has_attribute } from "../../commons/functions";
+import { feature_vex_enabled, getUserOptionText, has_attribute } from "../../commons/functions";
 import { AutocompleteInputMedium } from "../../commons/layout/themes";
 import { getSettingListSize, getSettingRowsPerPage } from "../../commons/user_settings/functions";
 import { ASSESSMENT_STATUS_NEEDS_APPROVAL, OBSERVATION_SEVERITY_CHOICES, OBSERVATION_STATUS_CHOICES } from "../types";
@@ -92,7 +92,7 @@ function listFilters(product: any) {
 
     filters.push(
         <ReferenceInput source="user" reference="users" sort={{ field: "full_name", order: "ASC" }} alwaysOn>
-            <AutocompleteInputMedium optionText="full_name" />
+            <AutocompleteInputMedium optionText={getUserOptionText} />
         </ReferenceInput>,
         <AutocompleteInput source="severity" label="Severity" choices={OBSERVATION_SEVERITY_CHOICES} alwaysOn />,
         <AutocompleteInput source="status" label="Status" choices={OBSERVATION_STATUS_CHOICES} alwaysOn />

--- a/frontend/src/core/product_members/ProductMemberAdd.tsx
+++ b/frontend/src/core/product_members/ProductMemberAdd.tsx
@@ -8,6 +8,7 @@ import AddButton from "../../commons/custom_fields/AddButton";
 import CancelButton from "../../commons/custom_fields/CancelButton";
 import Toolbar from "../../commons/custom_fields/Toolbar";
 import { validate_required } from "../../commons/custom_validators";
+import { getUserOptionText } from "../../commons/functions";
 import { AutocompleteInputWide } from "../../commons/layout/themes";
 
 export type ProductMemberAddProps = {
@@ -104,7 +105,7 @@ const ProductMemberAdd = ({ id }: ProductMemberAddProps) => {
                             sort={{ field: "full_name", order: "ASC" }}
                         >
                             <AutocompleteInputWide
-                                optionText="full_name"
+                                optionText={getUserOptionText}
                                 validate={validate_required}
                                 onChange={(e) => setUser(e)}
                             />

--- a/frontend/src/licenses/concluded_licenses/ConcludedLicenseEmbeddedList.tsx
+++ b/frontend/src/licenses/concluded_licenses/ConcludedLicenseEmbeddedList.tsx
@@ -12,7 +12,7 @@ import {
 
 import { CustomPagination } from "../../commons/custom_fields/CustomPagination";
 import { ProductReferenceInput } from "../../commons/custom_fields/ProductReferenceInput";
-import { humanReadableDate } from "../../commons/functions";
+import { getUserOptionText, humanReadableDate } from "../../commons/functions";
 import { AutocompleteInputMedium } from "../../commons/layout/themes";
 import { getSettingListSize, getSettingRowsPerPage } from "../../commons/user_settings/functions";
 import { AGE_CHOICES } from "../../core/types";
@@ -35,7 +35,7 @@ const listFilters = [
     <TextInput source="manual_concluded_license_expression" label="License expression" alwaysOn />,
     <TextInput source="manual_concluded_non_spdx_license" label="Non-SPDX license" alwaysOn />,
     <ReferenceInput source="user" reference="users" sort={{ field: "full_name", order: "ASC" }} alwaysOn>
-        <AutocompleteInputMedium optionText="full_name" />
+        <AutocompleteInputMedium optionText={getUserOptionText} />
     </ReferenceInput>,
     <AutocompleteInputMedium source="age" choices={AGE_CHOICES} alwaysOn />,
 ];

--- a/frontend/src/licenses/license_group_members/LicenseGroupMemberAdd.tsx
+++ b/frontend/src/licenses/license_group_members/LicenseGroupMemberAdd.tsx
@@ -7,6 +7,7 @@ import AddButton from "../../commons/custom_fields/AddButton";
 import CancelButton from "../../commons/custom_fields/CancelButton";
 import Toolbar from "../../commons/custom_fields/Toolbar";
 import { validate_required } from "../../commons/custom_validators";
+import { getUserOptionText } from "../../commons/functions";
 import { AutocompleteInputWide } from "../../commons/layout/themes";
 import { httpClient } from "../../commons/ra-data-django-rest-framework";
 
@@ -102,7 +103,7 @@ const LicenseGroupMemberAdd = ({ id }: LicenseGroupMemberAddProps) => {
                             sort={{ field: "full_name", order: "ASC" }}
                         >
                             <AutocompleteInputWide
-                                optionText="full_name"
+                                optionText={getUserOptionText}
                                 validate={validate_required}
                                 onChange={(e) => setUser(e)}
                             />

--- a/frontend/src/licenses/license_policy_members/LicensePolicyMemberAdd.tsx
+++ b/frontend/src/licenses/license_policy_members/LicensePolicyMemberAdd.tsx
@@ -7,6 +7,7 @@ import AddButton from "../../commons/custom_fields/AddButton";
 import CancelButton from "../../commons/custom_fields/CancelButton";
 import Toolbar from "../../commons/custom_fields/Toolbar";
 import { validate_required } from "../../commons/custom_validators";
+import { getUserOptionText } from "../../commons/functions";
 import { AutocompleteInputWide } from "../../commons/layout/themes";
 import { httpClient } from "../../commons/ra-data-django-rest-framework";
 
@@ -103,7 +104,7 @@ const LicensePolicyMemberAdd = ({ id }: LicensePolicyMemberAddProps) => {
                                 sort={{ field: "full_name", order: "ASC" }}
                             >
                                 <AutocompleteInputWide
-                                    optionText="full_name"
+                                    optionText={getUserOptionText}
                                     validate={validate_required}
                                     onChange={(e) => setUser(e)}
                                 />

--- a/frontend/src/notifications/NotificationList.tsx
+++ b/frontend/src/notifications/NotificationList.tsx
@@ -15,7 +15,7 @@ import {
 import notifications from ".";
 import { CustomPagination } from "../commons/custom_fields/CustomPagination";
 import { ProductReferenceInput } from "../commons/custom_fields/ProductReferenceInput";
-import { has_attribute } from "../commons/functions";
+import { getUserOptionText, has_attribute } from "../commons/functions";
 import ListHeader from "../commons/layout/ListHeader";
 import { AutocompleteInputMedium } from "../commons/layout/themes";
 import { getSettingListSize, getSettingRowsPerPage } from "../commons/user_settings/functions";
@@ -36,7 +36,7 @@ const listFilters = [
     <TextInput source="function" alwaysOn />,
     <ProductReferenceInput alwaysOn />,
     <ReferenceInput source="user" reference="users" sort={{ field: "full_name", order: "ASC" }} alwaysOn>
-        <AutocompleteInputMedium optionText="full_name" />
+        <AutocompleteInputMedium optionText={getUserOptionText} />
     </ReferenceInput>,
     <BooleanInput source="exclude_already_viewed" alwaysOn />,
 ];


### PR DESCRIPTION
## Context

The user search only matched `full_name`, but usernames and full names often differ. For example, searching for a username like `truong` wouldn’t return a full name like `Trường` (unless it was part of the full name). Displaying the username alongside the full name also helps distinguish between users with identical names.

## Feature
- Add username to UserViewSet search_fields so autocomplete search matches username as well as full name
- Show 'Full Name (username)' in user autocomplete options via shared getUserOptionText helper
- Match username in DesignatedApproversInput client-side suggestion filtering