### PR TITLE
fix: respect configured base URL for GitHub issue tracker

### DIFF
--- a/backend/application/core/api/serializers_product.py
+++ b/backend/application/core/api/serializers_product.py
@@ -508,7 +508,9 @@ class ProductSerializer(ProductListSerializer):  # pylint: disable=too-many-publ
 
     def validate(self, attrs: dict) -> dict:  # pylint: disable=too-many-branches
         # There are quite a lot of branches, but at least they are not nested too much
-        if attrs.get("issue_tracker_type") == Issue_Tracker.ISSUE_TRACKER_GITHUB:
+        if attrs.get("issue_tracker_type") == Issue_Tracker.ISSUE_TRACKER_GITHUB and not attrs.get(
+            "issue_tracker_base_url"
+        ):
             attrs["issue_tracker_base_url"] = "https://api.github.com"
 
         if not (

--- a/backend/application/issue_tracker/issue_trackers/github_issue_tracker.py
+++ b/backend/application/issue_tracker/issue_trackers/github_issue_tracker.py
@@ -113,10 +113,17 @@ class GitHubIssueTracker(BaseIssueTracker):
         response.raise_for_status()
 
     def get_frontend_issue_url(self, product: Product, issue_id: str) -> str:
-        return f"https://github.com/{product.issue_tracker_project_id}/issues/{issue_id}"
+        base_url = self._normalize_base_url(product.issue_tracker_base_url or "https://api.github.com")
+        if base_url.endswith("/api/v3"):
+            # GitHub Enterprise Server: API at https://github.example.com/api/v3
+            host = base_url[: -len("/api/v3")]
+        else:
+            host = "https://github.com"
+        return f"{host}/{product.issue_tracker_project_id}/issues/{issue_id}"
 
     def _get_issue_tracker_base_url(self, product: Product) -> str:
-        return f"https://api.github.com/repos/{product.issue_tracker_project_id}/issues"
+        base_url = self._normalize_base_url(product.issue_tracker_base_url or "https://api.github.com")
+        return f"{base_url}/repos/{product.issue_tracker_project_id}/issues"
 
     def _get_headers(self, product: Product) -> dict:
         return {

--- a/backend/unittests/issue_tracker/issue_trackers/test_github_issue_tracker.py
+++ b/backend/unittests/issue_tracker/issue_trackers/test_github_issue_tracker.py
@@ -330,3 +330,32 @@ class TestGitHubIssueTracker(BaseTestCase):
         issue_tracker = GitHubIssueTracker()
         frontend_issue_url = issue_tracker.get_frontend_issue_url(self.observation_1.product, "gh_1")
         self.assertEqual("https://github.com/gh_project_1/issues/gh_1", frontend_issue_url)
+
+    @patch("requests.post")
+    def test_create_issue_github_enterprise(self, post_mock):
+        self.observation_1.product.issue_tracker_base_url = "https://github.example.com/api/v3"
+        post_mock.return_value.raise_for_status.return_value = None
+        post_mock.return_value.json.return_value = {"number": "gh_1"}
+
+        issue_tracker = GitHubIssueTracker()
+        issue_id = issue_tracker.create_issue(self.observation_1)
+
+        self.assertEqual("gh_1", issue_id)
+        self.assertEqual(
+            "https://github.example.com/api/v3/repos/gh_project_1/issues",
+            post_mock.call_args.kwargs["url"],
+        )
+
+    def test_get_issue_tracker_base_url_github_com(self):
+        self.observation_1.product.issue_tracker_base_url = "https://api.github.com"
+        issue_tracker = GitHubIssueTracker()
+        self.assertEqual(
+            "https://api.github.com/repos/gh_project_1/issues",
+            issue_tracker._get_issue_tracker_base_url(self.observation_1.product),
+        )
+
+    def test_get_frontend_issue_url_github_enterprise(self):
+        self.observation_1.product.issue_tracker_base_url = "https://github.example.com/api/v3/"
+        issue_tracker = GitHubIssueTracker()
+        frontend_issue_url = issue_tracker.get_frontend_issue_url(self.observation_1.product, "gh_1")
+        self.assertEqual("https://github.example.com/gh_project_1/issues/gh_1", frontend_issue_url)

--- a/docs/integrations/issue_trackers.md
+++ b/docs/integrations/issue_trackers.md
@@ -21,7 +21,7 @@ The parameters for the issue tracker integration are set in the product:
 |---------------------|---|
 | **Active**          | Issues will only be pushed, if this parameter is set. |
 | **Type**            | Either **GitHub** or **GitLab** or **Jira** |
-| **Base URL**        | The base URL of the issue tracker. For **GitHub** it is `https://api.github.com`, for a self hosted **GitLab** it will be something like `https://gitlab.example.com`, for **Jira** it is `https:\\{organization_name}.atlassian.net`. |
+| **Base URL**        | The base URL of the issue tracker. For **GitHub** it is `https://api.github.com` (for a GitHub Enterprise Server installation it will be something like `https://github.example.com/api/v3`), for a self hosted **GitLab** it will be something like `https://gitlab.example.com`, for **Jira** it is `https:\\{organization_name}.atlassian.net`. |
 | **API key**          | An API key must be created in the issue tracker, having the permissions to create and update issues. |
 | **Project id**       | The path of the repository in its URL in **GitHub** or **GitLab**, e.g. `SecObserve/SecObserve`. For **Jira** it is the key of the project. |
 | **Labels**           | A comma separated list of labels, that will be set for the issue. Additional labels can be set in the issue tracker, they will be preserved when the issue is updated. |


### PR DESCRIPTION
## Summary
Makes the GitHub issue tracker work with GitHub Enterprise Server installations by respecting the configured base URL instead of always forcing `https://api.github.com`.

## What changed
- `ProductSerializer.validate` only defaults `issue_tracker_base_url` to `https://api.github.com` when the field is empty, instead of overwriting whatever the user entered on every save.
- `GitHubIssueTracker` builds API URLs from the stored base URL (falling back to `https://api.github.com` when empty), mirroring how `GitLabIssueTracker` already handles self-hosted instances.
- `get_frontend_issue_url` derives the web UI host from a GitHub Enterprise Server base URL ending in `/api/v3` (e.g. `https://github.example.com/api/v3` → issue links on `https://github.example.com/...`); plain `https://api.github.com` keeps linking to `https://github.com`.
- Documentation for the Base URL parameter mentions the GitHub Enterprise Server form.

## Why
Closes #4217. Entering a GitHub Enterprise Server API URL in the product's issue tracker settings was silently reverted to `https://api.github.com` on save, and even a stored enterprise URL was ignored by the tracker client, so issues always went to github.com. We run SecObserve against a GitHub Enterprise Server installation and have been carrying these changes as a patch in our image build.

## Testing
- Added unit tests: issue creation and API URLs against an enterprise base URL, the empty-base-URL fallback, and frontend issue URL derivation for both github.com and GitHub Enterprise Server.
- Existing GitHub issue tracker tests (which exercise the github.com default) pass unchanged.
- `black`, `isort`, `flake8`, `./bin/run_mypy.sh` and `./bin/run_pylint.sh` are clean.
- The same change (as an image-build patch) is running against a real GitHub Enterprise Server instance, where issues are created on the enterprise host.