### PR TITLE
feat: allow manually re-running a periodic background task

### DIFF
--- a/backend/application/background_tasks/api/serializers.py
+++ b/backend/application/background_tasks/api/serializers.py
@@ -16,6 +16,14 @@ class PeriodicTaskSerializer(ModelSerializer):
         fields = "__all__"
 
 
+class PeriodicTaskRegisteredSerializer(Serializer):
+    tasks = ListField(child=CharField())
+
+
+class PeriodicTaskRunSerializer(Serializer):
+    task = CharField(max_length=255)
+
+
 class BackgroundTaskBreakdownSerializer(Serializer):
     task = CharField()
     full = CharField()

--- a/backend/application/background_tasks/api/views.py
+++ b/backend/application/background_tasks/api/views.py
@@ -1,20 +1,30 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from huey.contrib.djhuey import HUEY as huey
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.filters import SearchFilter
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK, HTTP_202_ACCEPTED, HTTP_409_CONFLICT
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
 from application.background_tasks.api.filters import PeriodicTaskFilter
 from application.background_tasks.api.serializers import (
     BackgroundTaskStatisticsSerializer,
+    PeriodicTaskRegisteredSerializer,
+    PeriodicTaskRunSerializer,
     PeriodicTaskSerializer,
 )
 from application.background_tasks.models import Periodic_Task
+from application.background_tasks.services.registry import (
+    PERIODIC_TASKS,
+    get_periodic_task,
+)
+from application.background_tasks.types import Status
 from application.commons.api.permissions import UserHasSuperuserPermission
 
 
@@ -25,6 +35,42 @@ class PeriodicTaskViewSet(GenericViewSet, ListModelMixin, RetrieveModelMixin):
     queryset = Periodic_Task.objects.all()
     filter_backends = [SearchFilter, DjangoFilterBackend]
     search_fields = ["task"]
+
+    @extend_schema(
+        methods=["GET"],
+        request=None,
+        responses={HTTP_200_OK: PeriodicTaskRegisteredSerializer},
+    )
+    @action(detail=False, methods=["get"])
+    def registered_tasks(self, request: Request) -> Response:
+        response_serializer = PeriodicTaskRegisteredSerializer({"tasks": sorted(PERIODIC_TASKS.keys())})
+        return Response(response_serializer.data)
+
+    @extend_schema(
+        methods=["POST"],
+        request=PeriodicTaskRunSerializer,
+        responses={HTTP_202_ACCEPTED: None},
+    )
+    @action(detail=False, methods=["post"])
+    def run(self, request: Request) -> Response:
+        request_serializer = PeriodicTaskRunSerializer(data=request.data)
+        if not request_serializer.is_valid():
+            raise ValidationError(request_serializer.errors)
+
+        task_name = request_serializer.validated_data.get("task")
+        periodic_task = get_periodic_task(task_name)
+        if periodic_task is None:
+            raise ValidationError(f"Task '{task_name}' does not exist")
+
+        if Periodic_Task.objects.filter(task=task_name, status=Status.STATUS_RUNNING).exists():
+            return Response(
+                {"detail": f"Task '{task_name}' is currently running"},
+                status=HTTP_409_CONFLICT,
+            )
+
+        periodic_task()
+
+        return Response(status=HTTP_202_ACCEPTED)
 
 
 class BackgroundTaskView(APIView):

--- a/backend/application/background_tasks/services/registry.py
+++ b/backend/application/background_tasks/services/registry.py
@@ -1,0 +1,27 @@
+from importlib import import_module
+from typing import Any, Callable, Optional
+
+# Maps the name of a periodic task to the dotted path of its Huey task wrapper.
+# The tasks are resolved lazily because importing the task modules reads the
+# settings from the database, which fails on a not yet migrated database.
+PERIODIC_TASKS: dict[str, str] = {
+    "Import observations from API configurations, OSV and VulnerableCode": (
+        "application.background_tasks.periodic_tasks.import_observations_tasks.task_api_import"
+    ),
+    "Import EPSS and cvss-bt": "application.background_tasks.periodic_tasks.epss_tasks.task_import_epss",
+    "Import SPDX licenses": "application.background_tasks.periodic_tasks.license_tasks.task_spdx_license_import",
+    "Branch housekeeping": "application.background_tasks.periodic_tasks.core_tasks.task_branch_housekeeping",
+    "Expire risk acceptances": "application.background_tasks.periodic_tasks.core_tasks.task_expire_risk_acceptances",
+    "Calculate product metrics": (
+        "application.background_tasks.periodic_tasks.metrics_tasks.task_calculate_product_metrics"
+    ),
+}
+
+
+def get_periodic_task(name: str) -> Optional[Callable[[], Any]]:
+    dotted_path = PERIODIC_TASKS.get(name)
+    if dotted_path is None:
+        return None
+
+    module_name, _, function_name = dotted_path.rpartition(".")
+    return getattr(import_module(module_name), function_name)

--- a/backend/application/background_tasks/services/task_base.py
+++ b/backend/application/background_tasks/services/task_base.py
@@ -21,6 +21,9 @@ logger = logging.getLogger("secobserve.background_tasks")
 # max_length is typed as Optional, but it is always set for the CharField "message"
 MESSAGE_MAX_LENGTH = cast(int, Periodic_Task._meta.get_field("message").max_length)
 
+# Names of all periodic tasks, used to check that the registry is complete
+PERIODIC_TASK_NAMES: set[str] = set()
+
 
 def _truncate_message(message: str) -> str:
     if len(message) <= MESSAGE_MAX_LENGTH:
@@ -29,6 +32,8 @@ def _truncate_message(message: str) -> str:
 
 
 def so_periodic_task(name: str) -> Callable:
+    PERIODIC_TASK_NAMES.add(name)
+
     def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
         @lock_task(name)

--- a/backend/unittests/authorization/api/test_authorization_periodic_tasks.py
+++ b/backend/unittests/authorization/api/test_authorization_periodic_tasks.py
@@ -16,3 +16,13 @@ class TestAuthorizationPeriodicTasks(TestAuthorizationBase):
         self._test_api(APITest("db_internal_write", "get", "/api/periodic_tasks/", None, 403, None))
 
         self._test_api(APITest("db_internal_write", "get", "/api/periodic_tasks/1/", None, 403, None))
+
+        expected_data = "{'tasks': ['Branch housekeeping', 'Calculate product metrics', 'Expire risk acceptances', 'Import EPSS and cvss-bt', 'Import SPDX licenses', 'Import observations from API configurations, OSV and VulnerableCode']}"
+        self._test_api(APITest("db_admin", "get", "/api/periodic_tasks/registered_tasks/", None, 200, expected_data))
+
+        self._test_api(APITest("db_internal_write", "get", "/api/periodic_tasks/registered_tasks/", None, 403, None))
+
+        post_data = {"task": "Unknown task"}
+        self._test_api(APITest("db_admin", "post", "/api/periodic_tasks/run/", post_data, 400, None))
+
+        self._test_api(APITest("db_internal_write", "post", "/api/periodic_tasks/run/", post_data, 403, None))

--- a/backend/unittests/background_tasks/api/test_views.py
+++ b/backend/unittests/background_tasks/api/test_views.py
@@ -1,8 +1,17 @@
 from unittest.mock import MagicMock, patch
 
-from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
+from django.utils import timezone
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_202_ACCEPTED,
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+    HTTP_409_CONFLICT,
+)
 from rest_framework.test import APIClient
 
+from application.background_tasks.models import Periodic_Task
+from application.background_tasks.types import Status
 from unittests.base_test_case import BaseTestCase
 
 URL = "/api/status/background_task_statistics/"
@@ -52,3 +61,95 @@ class TestBackgroundTaskView(BaseTestCase):
 
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
         mock_huey._stats.task_breakdown.assert_not_called()
+
+
+REGISTERED_TASKS_URL = "/api/periodic_tasks/registered_tasks/"
+RUN_URL = "/api/periodic_tasks/run/"
+
+
+class TestPeriodicTaskRun(BaseTestCase):
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_registered_tasks(self, mock_authentication):
+        mock_authentication.return_value = self.user_admin, None
+
+        api_client = APIClient()
+        response = api_client.get(REGISTERED_TASKS_URL)
+
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        expected_tasks = [
+            "Branch housekeeping",
+            "Calculate product metrics",
+            "Expire risk acceptances",
+            "Import EPSS and cvss-bt",
+            "Import SPDX licenses",
+            "Import observations from API configurations, OSV and VulnerableCode",
+        ]
+        self.assertEqual(expected_tasks, response.data["tasks"])
+
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_registered_tasks_forbidden(self, mock_authentication):
+        mock_authentication.return_value = self.user_internal, None
+
+        api_client = APIClient()
+        response = api_client.get(REGISTERED_TASKS_URL)
+
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    @patch("application.background_tasks.api.views.get_periodic_task")
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_run_successful(self, mock_authentication, mock_get_periodic_task):
+        mock_authentication.return_value = self.user_admin, None
+        mock_task = MagicMock()
+        mock_get_periodic_task.return_value = mock_task
+
+        api_client = APIClient()
+        response = api_client.post(RUN_URL, {"task": "Test task"}, format="json")
+
+        self.assertEqual(HTTP_202_ACCEPTED, response.status_code)
+        mock_get_periodic_task.assert_called_once_with("Test task")
+        mock_task.assert_called_once_with()
+
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_run_unknown_task(self, mock_authentication):
+        mock_authentication.return_value = self.user_admin, None
+
+        api_client = APIClient()
+        response = api_client.post(RUN_URL, {"task": "Unknown task"}, format="json")
+
+        self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
+
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_run_missing_task(self, mock_authentication):
+        mock_authentication.return_value = self.user_admin, None
+
+        api_client = APIClient()
+        response = api_client.post(RUN_URL, {}, format="json")
+
+        self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
+
+    @patch("application.background_tasks.api.views.get_periodic_task")
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_run_already_running(self, mock_authentication, mock_get_periodic_task):
+        mock_authentication.return_value = self.user_admin, None
+        mock_task = MagicMock()
+        mock_get_periodic_task.return_value = mock_task
+        Periodic_Task(task="Test task", start_time=timezone.now(), status=Status.STATUS_RUNNING).save()
+
+        api_client = APIClient()
+        response = api_client.post(RUN_URL, {"task": "Test task"}, format="json")
+
+        self.assertEqual(HTTP_409_CONFLICT, response.status_code)
+        mock_task.assert_not_called()
+
+    @patch("application.background_tasks.api.views.get_periodic_task")
+    @patch("application.access_control.services.api_token_authentication.APITokenAuthentication.authenticate")
+    def test_run_forbidden(self, mock_authentication, mock_get_periodic_task):
+        mock_authentication.return_value = self.user_internal, None
+        mock_task = MagicMock()
+        mock_get_periodic_task.return_value = mock_task
+
+        api_client = APIClient()
+        response = api_client.post(RUN_URL, {"task": "Test task"}, format="json")
+
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        mock_task.assert_not_called()

--- a/backend/unittests/background_tasks/services/test_registry.py
+++ b/backend/unittests/background_tasks/services/test_registry.py
@@ -1,0 +1,18 @@
+from application.background_tasks.services.registry import (
+    PERIODIC_TASKS,
+    get_periodic_task,
+)
+from application.background_tasks.services.task_base import PERIODIC_TASK_NAMES
+from unittests.base_test_case import BaseTestCase
+
+
+class TestRegistry(BaseTestCase):
+    def test_registry_is_complete(self):
+        # resolving imports the task modules, which populates PERIODIC_TASK_NAMES
+        for name in PERIODIC_TASKS:
+            self.assertIsNotNone(get_periodic_task(name))
+
+        self.assertEqual(PERIODIC_TASK_NAMES, set(PERIODIC_TASKS.keys()))
+
+    def test_get_periodic_task_unknown(self):
+        self.assertIsNone(get_periodic_task("Unknown task"))

--- a/frontend/src/background_tasks/periodic_tasks/PeriodicTaskEmbeddedList.tsx
+++ b/frontend/src/background_tasks/periodic_tasks/PeriodicTaskEmbeddedList.tsx
@@ -1,4 +1,6 @@
+import { Stack } from "@mui/material";
 import humanizeDuration from "humanize-duration";
+import { useEffect, useState } from "react";
 import {
     AutocompleteInput,
     Datagrid,
@@ -8,21 +10,19 @@ import {
     ListContextProvider,
     ResourceContextProvider,
     TextField,
-    TextInput,
     useListController,
 } from "react-admin";
 
 import { CustomPagination } from "../../commons/custom_fields/CustomPagination";
 import { PeriodicTaskStatusField } from "../../commons/custom_fields/PeriodicTaskStatusField";
+import { httpClient } from "../../commons/ra-data-django-rest-framework";
 import { getSettingListSize, getSettingRowsPerPage } from "../../commons/user_settings/functions";
 import { PERIODIC_TASKS_STATUS_CHOICES } from "../types";
-
-const listFilters = [
-    <TextInput key="task-filter" source="task" alwaysOn />,
-    <AutocompleteInput key="status-filter" source="status" choices={PERIODIC_TASKS_STATUS_CHOICES} alwaysOn />,
-];
+import PeriodicTaskRunNow from "./PeriodicTaskRunNow";
 
 const PeriodicTaskEmbeddedList = () => {
+    const [registeredTasks, setRegisteredTasks] = useState<string[]>([]);
+
     const listContext = useListController({
         filter: {},
         perPage: getSettingRowsPerPage(),
@@ -32,15 +32,51 @@ const PeriodicTaskEmbeddedList = () => {
         storeKey: "periodic_tasks.embedded",
     });
 
+    useEffect(() => {
+        httpClient(window.__RUNTIME_CONFIG__.API_BASE_URL + "/periodic_tasks/registered_tasks/", {
+            method: "GET",
+        }).then((registered) => {
+            setRegisteredTasks(registered.json.tasks);
+        });
+    }, []);
+
     if (listContext.isLoading) {
         return <div>Loading...</div>;
     }
+
+    const listFilters = [
+        <AutocompleteInput
+            key="task-filter"
+            source="task"
+            choices={registeredTasks.map((registered_task) => ({ id: registered_task, name: registered_task }))}
+            alwaysOn
+            sx={{ width: 480 }}
+        />,
+        <AutocompleteInput key="status-filter" source="status" choices={PERIODIC_TASKS_STATUS_CHOICES} alwaysOn />,
+    ];
+
+    const selected_task = registeredTasks.includes(listContext.filterValues.task)
+        ? listContext.filterValues.task
+        : null;
 
     return (
         <ResourceContextProvider value="periodic_tasks">
             <ListContextProvider value={listContext}>
                 <div style={{ width: "100%" }}>
-                    <FilterForm filters={listFilters} />
+                    <Stack
+                        direction="row"
+                        sx={{
+                            alignItems: "center",
+                            marginBottom: 1,
+                            // shrink the filter form to its content, so that the Run now
+                            // button can sit next to the filters
+                            "& form": { flex: "0 1 auto", minHeight: "unset", paddingBottom: 0 },
+                            "& form .RaFilterForm-filterFormInput .MuiFormControl-root": { marginTop: 0 },
+                        }}
+                    >
+                        <FilterForm filters={listFilters} />
+                        <PeriodicTaskRunNow task={selected_task} />
+                    </Stack>
                     <Datagrid
                         size={getSettingListSize()}
                         rowClick={false}

--- a/frontend/src/background_tasks/periodic_tasks/PeriodicTaskRunNow.tsx
+++ b/frontend/src/background_tasks/periodic_tasks/PeriodicTaskRunNow.tsx
@@ -1,0 +1,73 @@
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import { Button } from "@mui/material";
+import { useState } from "react";
+import { Confirm, useNotify, useRefresh } from "react-admin";
+
+import { Spinner } from "../../commons/custom_fields/Spinner";
+import { httpClient } from "../../commons/ra-data-django-rest-framework";
+
+type PeriodicTaskRunNowProps = {
+    task: string | null;
+};
+
+const PeriodicTaskRunNow = ({ task }: PeriodicTaskRunNowProps) => {
+    const [open, setOpen] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const refresh = useRefresh();
+    const notify = useNotify();
+    const handleClick = () => setOpen(true);
+    const handleDialogClose = () => setOpen(false);
+
+    const handleConfirm = async () => {
+        setLoading(true);
+
+        httpClient(window.__RUNTIME_CONFIG__.API_BASE_URL + "/periodic_tasks/run/", {
+            method: "POST",
+            body: JSON.stringify({ task: task }),
+        })
+            .then(() => {
+                refresh();
+                setOpen(false);
+                setLoading(false);
+                notify("Task enqueued", {
+                    type: "success",
+                });
+            })
+            .catch((error) => {
+                refresh();
+                setOpen(false);
+                setLoading(false);
+                notify(error.message, {
+                    type: "warning",
+                });
+            });
+    };
+
+    return (
+        <>
+            <Button
+                variant="contained"
+                onClick={handleClick}
+                disabled={task === null}
+                startIcon={<PlayArrowIcon />}
+                sx={{ width: "fit-content", fontSize: "0.8125rem", whiteSpace: "nowrap" }}
+            >
+                Run now
+            </Button>
+            <Confirm
+                isOpen={open && !loading}
+                title="Run now"
+                content={
+                    <span>
+                        Are you sure you want to run the task <strong>{task}</strong> now?
+                    </span>
+                }
+                onConfirm={handleConfirm}
+                onClose={handleDialogClose}
+            />
+            <Spinner open={open && loading} />
+        </>
+    );
+};
+
+export default PeriodicTaskRunNow;

--- a/frontend/src/commons/custom_fields/PeriodicTaskStatusField.tsx
+++ b/frontend/src/commons/custom_fields/PeriodicTaskStatusField.tsx
@@ -10,7 +10,7 @@ export const PeriodicTaskStatusField = ({ label }: PeriodicTaskStatusFieldProps)
     function get_status_color() {
         if (record?.status === "Success") {
             return "#00aa00";
-        } else if (record?.status === "Failed") {
+        } else if (record?.status === "Failure") {
             return "#d4333f";
         } else if (record?.status === "Running") {
             return "#00B4F0";


### PR DESCRIPTION
  Adds a superuser only **"RUN NOW"** action to the **Background Tasks** page that enqueues a registered periodic task immediately via Huey:

- `GET /api/periodic_tasks/registered_tasks/` lists the registered task names
- `POST /api/periodic_tasks/run/` enqueues the task (202), rejects unknown tasks (400) and tasks that are currently running (409)
- The **Task** filter is now an autocomplete over the registered task names. Selecting a task filters the executions and enables the **Run now** button, guarded by a confirmation dialog
- Tasks are resolved lazily via a registry of dotted paths, because importing the periodic task modules reads the settings from the database at import time
- Fix `PeriodicTaskStatusField` compared the status against `"Failed"` instead of `"Failure"`, so failed executions rendered grey instead of red

<img width="1137" height="397" alt="image" src="https://github.com/user-attachments/assets/b5000932-e006-4da8-9918-6458c96d0a7b" />

Closes #4676