### PR TITLE
fix: lock the VEX counter row when creating document base ids

### DIFF
--- a/backend/application/vex/services/vex_base.py
+++ b/backend/application/vex/services/vex_base.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from django.db import transaction
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
@@ -12,9 +13,12 @@ from application.vex.models import VEX_Counter
 
 def create_document_base_id(document_id_prefix: str) -> str:
     year = timezone.now().year
-    counter = VEX_Counter.objects.get_or_create(document_id_prefix=document_id_prefix, year=year)[0]
-    counter.counter += 1
-    counter.save()
+    with transaction.atomic():
+        counter = VEX_Counter.objects.select_for_update().get_or_create(
+            document_id_prefix=document_id_prefix, year=year
+        )[0]
+        counter.counter += 1
+        counter.save()
     return f"{counter.year}_{counter.counter:04d}"
 
 

--- a/backend/unittests/vex/services/test_vex_base.py
+++ b/backend/unittests/vex/services/test_vex_base.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from application.vex.models import VEX_Counter
+from application.vex.services.vex_base import create_document_base_id
+
+
+class TestCreateDocumentBaseId(TestCase):
+    def test_increments_per_prefix_and_year(self):
+        year = timezone.now().year
+
+        self.assertEqual(create_document_base_id("PREFIX"), f"{year}_0001")
+        self.assertEqual(create_document_base_id("PREFIX"), f"{year}_0002")
+        self.assertEqual(create_document_base_id("OTHER"), f"{year}_0001")
+
+        self.assertEqual(VEX_Counter.objects.get(document_id_prefix="PREFIX", year=year).counter, 2)
+        self.assertEqual(VEX_Counter.objects.get(document_id_prefix="OTHER", year=year).counter, 1)
+
+    def test_locks_the_counter_row(self):
+        # SQLite ignores select_for_update(), so the lock that keeps concurrent
+        # requests from reading the same counter cannot be exercised here;
+        # assert the lock is requested instead.
+        counter = VEX_Counter(document_id_prefix="PREFIX", year=2026, counter=41)
+        with patch("application.vex.services.vex_base.VEX_Counter.objects") as objects:
+            objects.select_for_update.return_value.get_or_create.return_value = (counter, False)
+
+            self.assertEqual(create_document_base_id("PREFIX"), "2026_0042")
+
+            objects.select_for_update.assert_called_once_with()
+            objects.select_for_update.return_value.get_or_create.assert_called_once_with(
+                document_id_prefix="PREFIX", year=timezone.now().year
+            )


### PR DESCRIPTION
## Summary

`create_document_base_id` incremented `VEX_Counter` with an unlocked read-modify-write (`get_or_create` → `counter += 1` → `save()`). Two concurrent `POST /api/vex/openvex_document/create/` (or CSAF) requests sharing a `document_id_prefix` read the same counter value, and the second insert fails the `(document_id_prefix, document_base_id)` unique constraint with an `IntegrityError` (HTTP 500).

Fixes #4771

## Changes

- `application/vex/services/vex_base.py`: take `select_for_update()` on the counter row inside `transaction.atomic()`. With `ATOMIC_REQUESTS` the lock is held until the request commits, so concurrent creations on the same prefix cannot produce the same id. `select_for_update()` is a no-op on SQLite, so the unit-test backend is unaffected.
- `application/vex/services/openvex_generator.py` and `csaf_generator.py`: generate the statements / vulnerabilities and product tree **before** allocating the document id and inserting the rows. Because the lock lives until commit, allocating first would hold it across the whole export, which takes tens of seconds for large products (measured ~45 s for a product with ~1800 statements) and would serialise concurrent creations behind each other. With generation first, the lock is held for milliseconds and concurrent exports still run in parallel. This also removes the create-then-delete dance for exports with no content: nothing is inserted until there is something to export.
- `unittests/vex/services/test_vex_base.py`: covers the per-prefix, per-year increment and asserts the row lock is requested (the lock itself cannot be exercised on SQLite).

## Testing

- `docker compose -f docker-compose-unittests.yml run --rm django unittests.vex.api.test_views_openvex unittests.vex.api.test_views_csaf unittests.vex.services.test_vex_base unittests.vex.services.test_csaf_generator_vulnerability`: 16 tests OK.
- `black --check`, `isort --check-only`, `flake8` clean on the changed files.
- Against a PostgreSQL deployment where parallel CI pipelines previously produced ~24 of these 500s per day: eight concurrent creates on the same prefix now yield eight distinct sequential ids and no IntegrityError.
