### PR TITLE
fix: generate VEX content before allocating the document id

### DIFF
--- a/backend/application/vex/services/csaf_generator.py
+++ b/backend/application/vex/services/csaf_generator.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import jsonpickle
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import NotFound
 
 from application.access_control.services.current_user import get_current_user
 from application.authorization.services.authorization import user_has_permission_or_403
@@ -76,6 +76,21 @@ def create_csaf_document(parameters: CSAFCreateParameters) -> Optional[CSAFRoot]
     if not user:
         raise ValueError("No user in request")
 
+    # Generate the content before allocating the document id: the counter row
+    # stays locked until the request commits, so the lock must not span the
+    # expensive part of the export.
+    if parameters.product:
+        vulnerabilities, product_tree = _get_content_for_product(
+            parameters.product, parameters.vulnerability_names, parameters.branches
+        )
+    else:
+        vulnerabilities, product_tree = _get_content_for_vulnerabilities(parameters.vulnerability_names)
+
+    if not vulnerabilities:
+        return None
+
+    validate_not_affected_impact_statements(vulnerabilities)
+
     document_base_id = create_document_base_id(parameters.document_id_prefix)
 
     csaf = CSAF.objects.create(
@@ -106,25 +121,6 @@ def create_csaf_document(parameters: CSAFCreateParameters) -> Optional[CSAFRoot]
         CSAF_Branch.objects.create(csaf=csaf, branch=branch)
 
     csaf_root = create_csaf_root(csaf)
-
-    vulnerabilities = []
-
-    if parameters.product:
-        vulnerabilities, product_tree = _get_content_for_product(
-            parameters.product, parameters.vulnerability_names, parameters.branches
-        )
-    else:
-        vulnerabilities, product_tree = _get_content_for_vulnerabilities(parameters.vulnerability_names)
-
-    if not vulnerabilities:
-        csaf.delete()
-        return None
-
-    try:
-        validate_not_affected_impact_statements(vulnerabilities)
-    except ValidationError:
-        csaf.delete()
-        raise
 
     csaf_content = CSAFContent(vulnerabilities, product_tree)
     content_json = jsonpickle.encode(csaf_content, unpicklable=False)

--- a/backend/application/vex/services/openvex_generator.py
+++ b/backend/application/vex/services/openvex_generator.py
@@ -66,6 +66,19 @@ def create_openvex_document(
     if not user:
         raise ValueError("No user in request")
 
+    # Generate the statements before allocating the document id: the counter
+    # row stays locked until the request commits, so the lock must not span
+    # the expensive part of the export.
+    if parameters.product:
+        statements = _get_statements_for_product(
+            parameters.product, parameters.vulnerability_names, parameters.branches
+        )
+    else:
+        statements = _get_statements_for_vulnerabilities(parameters.vulnerability_names)
+
+    if not statements:
+        return None
+
     document_base_id = create_document_base_id(parameters.document_id_prefix)
 
     openvex = OpenVEX.objects.create(
@@ -98,18 +111,6 @@ def create_openvex_document(
         tooling="SecObserve / " + __version__,
         statements=[],
     )
-
-    statements = []
-    if parameters.product:
-        statements = _get_statements_for_product(
-            parameters.product, parameters.vulnerability_names, parameters.branches
-        )
-    else:
-        statements = _get_statements_for_vulnerabilities(parameters.vulnerability_names)
-
-    if not statements:
-        openvex.delete()
-        return None
 
     statements_json = jsonpickle.encode(statements, unpicklable=False)
     statements_hash = hashlib.sha256(statements_json.casefold().encode("utf-8").strip()).hexdigest()


### PR DESCRIPTION
## Summary

Fixes #4776. Follow-up to #4773 (#4771). With the counter row now locked until the request commits, allocating the document id before generating the export holds that lock across the whole export. For large products that is tens of seconds (measured ~45 s for a product with ~1800 statements on PostgreSQL), so concurrent creations on the same prefix queue behind each other and can hit gateway timeouts.

## Change

`create_openvex_document` and `create_csaf_document` now generate the statements (OpenVEX) or the vulnerabilities and product tree (CSAF) first, then take the counter and insert the rows. The lock is held for milliseconds and concurrent exports run in parallel again.

This also removes the create-then-delete dance for exports with no content: nothing is inserted until there is something to export. Behaviour is otherwise unchanged; `validate_not_affected_impact_statements` still raises before anything is written.

## Testing

- `docker compose -f docker-compose-unittests.yml run --rm django unittests.vex.api.test_views_openvex unittests.vex.api.test_views_csaf unittests.vex.services.test_vex_base unittests.vex.services.test_csaf_generator_vulnerability`: 16 tests OK.
- `black --check`, `isort --check-only`, `flake8` clean on the changed files.
- Against our PostgreSQL deployment with the lock alone, eight concurrent creates on one prefix gave eight distinct ids but four gateway timeouts while queued; with this change applied at image build time they complete in parallel.